### PR TITLE
experimental refs implementation

### DIFF
--- a/library/src/main/java/trikita/anvil/BaseAttrs.java
+++ b/library/src/main/java/trikita/anvil/BaseAttrs.java
@@ -217,6 +217,18 @@ public class BaseAttrs extends Nodes {
 		};
 	}
 
+	public static AttrNode ref(final RefSet refs, final String name) {
+		final List<Object> params = new ArrayList<Object>() {{
+			add(refs); add(name);
+		}};
+
+		return new SimpleAttrNode(params) {
+			public void apply(View v) {
+				refs.set(name, v);
+			}
+		};
+	}
+
 	/**
 	 * An attribute node that has some actions to be performed when old value is
 	 * replaced by the new value. Useful to clean up the listeners added by

--- a/library/src/main/java/trikita/anvil/RefSet.java
+++ b/library/src/main/java/trikita/anvil/RefSet.java
@@ -1,0 +1,21 @@
+package trikita.anvil;
+
+import android.view.View;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Created by kyle on 6/1/15.
+ */
+public class RefSet {
+    private Map<String, View> refs = new HashMap<String, View>();
+
+    public View get(String ref) {
+        return refs.get(ref);
+    }
+
+    public void set(String ref, View v) {
+        refs.put(ref, v);
+    }
+}

--- a/library/src/main/java/trikita/anvil/RefSet.java
+++ b/library/src/main/java/trikita/anvil/RefSet.java
@@ -1,15 +1,23 @@
 package trikita.anvil;
 
+import android.util.Log;
 import android.view.View;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
  * Created by kyle on 6/1/15.
  */
 public class RefSet {
-    private Map<String, View> refs = new HashMap<String, View>();
+    private Map<String, View> refs = new HashMap();
+    private Map<String, List<RefSetObserver>> observers = new HashMap();
+
+    public interface RefSetObserver {
+        public void update(View v);
+    }
 
     public View get(String ref) {
         return refs.get(ref);
@@ -17,5 +25,17 @@ public class RefSet {
 
     public void set(String ref, View v) {
         refs.put(ref, v);
+        if(null != observers.get(ref))
+            for( RefSetObserver r : observers.get(ref) )
+                r.update(v);
+    }
+
+    public void onUpdate(String ref, RefSetObserver o) {
+        List refObservers = observers.get(ref);
+        if( null == refObservers ) {
+            refObservers = new ArrayList();
+            observers.put(ref, refObservers);
+        }
+        refObservers.add(o);
     }
 }


### PR DESCRIPTION
This adds basic ref functionality. Currently the user is required to instantiate and manage a `RefSet`, which is really just a wrapper for a map of refs to views. Alternatively, a RefSet could be implicitly created for a view or view hierarchy, but I think that passing it in explicitly feels more functional, and I prefer it slightly. It also keeps the implementation extremely simple, which I think is a plus.

This is still a work in progress; I'm planning on adding a callback to the RefSet that a user can be notified when a ref has been updated.