### PR TITLE
Demonstrate static imports that make examples work

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,14 @@ view properties as your data changes.
 
 Anvil simplifies most of this boring routine.
 
-First, declare your layout, assign event listeners and bind data:
+First, add two static imports that make it much easier to read and write your view:
+
+``` java
+import static trikita.anvil.BaseDSL.*;
+import static trikita.anvil.DSL.*;
+```
+
+Next, declare your layout, assign event listeners and bind data:
 
 ``` Java
 public int ticktock = 0;

--- a/README.md
+++ b/README.md
@@ -58,10 +58,9 @@ view properties as your data changes.
 
 Anvil simplifies most of this boring routine.
 
-First, add two static imports that make it much easier to read and write your view:
+First, add a static import that makes it much easier to write your view:
 
 ``` java
-import static trikita.anvil.BaseDSL.*;
 import static trikita.anvil.DSL.*;
 ```
 


### PR DESCRIPTION
I couldn't find this info anywhere. It's necessary to get the examples to compile and it's not obvious without digging into source code of examples.