### PR TITLE
Add textSize setter that has units

### DIFF
--- a/anvil/src/main/java/trikita/anvil/BaseDSL.java
+++ b/anvil/src/main/java/trikita/anvil/BaseDSL.java
@@ -309,6 +309,20 @@ public class BaseDSL {
 		}
 	}
 
+	public static Void textSize(int unit, float size) {
+		return attr(TextSizeWithUnitFunc.instance, new AbstractMap.SimpleImmutableEntry<>(unit, size));
+	}
+
+	private final static class TextSizeWithUnitFunc
+			implements Anvil.AttrFunc<Map.Entry<Integer, Float>> {
+		private final static TextSizeWithUnitFunc instance = new TextSizeWithUnitFunc();
+		public void apply(View v, Map.Entry<Integer, Float> size, Map.Entry<Integer, Float> old) {
+			if (v instanceof TextView) {
+				((TextView) v).setTextSize(size.getKey(), size.getValue());
+			}
+		}
+	}
+
 	public static Void typeface(String font) {
 		return attr(TypefaceFunc.instance, font);
 	}


### PR DESCRIPTION
TextView sizes are often set in SP which doesn't look possible in Anvil right now. This mirrors the setTextSize function.

I just got started with Anvil and may be wrong about this. Also, I'm not sure how to compile and use a custom version of Anvil, so I haven't tested or even compiled this. Sorry. I thought it was too useful to not add to the project. I'll be happy to fix it.