### PR TITLE
Set the text of the View before firing callbacks

### DIFF
--- a/anvil/src/main/java/trikita/anvil/BaseDSL.java
+++ b/anvil/src/main/java/trikita/anvil/BaseDSL.java
@@ -449,13 +449,14 @@ public class BaseDSL {
 		    TextView old = CURRENT_INPUT_TEXT_VIEW;
 		    CURRENT_INPUT_TEXT_VIEW = this.v;
 		if (this.text.equals(s.toString()) == false) {
+		    this.text = s.toString();
+				
 		    if (this.watcher != null) {
 			this.watcher.onTextChanged(s, from, before, n);
 		    }
 		    if (this.simpleWatcher != null) {
 			this.simpleWatcher.onTextChanged(s);
 		    }
-		    this.text = s.toString();
 
 		    Anvil.render();
 		    CURRENT_INPUT_TEXT_VIEW = old;


### PR DESCRIPTION
## Problem

If a `watcher` or `simpleWatcher` call `Anvil.render()` themselves, the `EditTextView` will act inappropriately, adding the latest character at the beginning of the current string instead of the spot the cursor was placed.

Note: It may seem silly to call `Anvil.render()` within the callback, but using the Redux pattern this is bound to happen.

Generally, with redux-style apps, the view layer will be listening to state changes and calling `Anvil.render` upon state changes (because state changes are not only produced by interacting with UI elements, but could also be updated in response to a network call, for example). Since both Jedux and Bansa immediately/synchronously invoke the reducers and then callbacks, the `Anvil.render()` from the state change subscriber will actually be called BEFORE `this.text` is set.

## Solution

Update `this.text` immediately before firing callbacks. Then, on the next render, `this.text` should be in the right place and Anvil should handle everything correctly!

Please let me know if this works, or there are other issues! I'd implemented my own TextWatcher previously with Anvil and I know these things are a total pain, so I might have missed something here!

Gif of the problem:

![problem](https://cloud.githubusercontent.com/assets/126604/14358877/4711c8ba-fcef-11e5-8cdc-3e10c06f7ffc.gif)


And with the fix applied:

![fixed](https://cloud.githubusercontent.com/assets/126604/14358655/3a1e1a7e-fcee-11e5-86d0-fdd4b13dc54c.gif)
