### PR TITLE
anvilgen: deal with conflicting package names

### DIFF
--- a/anvil-appcompat-v7/src/main/AndroidManifest.xml
+++ b/anvil-appcompat-v7/src/main/AndroidManifest.xml
@@ -1,2 +1,2 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="trikita.anvil" />
+<manifest package="trikita.anvil.appcompat.v7" />

--- a/anvil-appcompat-v7/src/main/java/trikita/anvil/appcompat/v7/AppCompatv7DSL.java
+++ b/anvil-appcompat-v7/src/main/java/trikita/anvil/appcompat/v7/AppCompatv7DSL.java
@@ -1,4 +1,4 @@
-package trikita.anvil;
+package trikita.anvil.appcompat.v7;
 
 import android.app.SearchableInfo;
 import android.content.res.ColorStateList;
@@ -56,6 +56,8 @@ import java.lang.Float;
 import java.lang.Integer;
 import java.lang.String;
 import java.lang.Void;
+import trikita.anvil.Anvil;
+import trikita.anvil.BaseDSL;
 
 /**
  * DSL for creating views and settings their attributes.

--- a/anvil-design/src/main/AndroidManifest.xml
+++ b/anvil-design/src/main/AndroidManifest.xml
@@ -1,2 +1,2 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="trikita.anvil" />
+<manifest package="trikita.anvil.design" />

--- a/anvil-design/src/main/java/trikita/anvil/design/DesignDSL.java
+++ b/anvil-design/src/main/java/trikita/anvil/design/DesignDSL.java
@@ -1,4 +1,4 @@
-package trikita.anvil;
+package trikita.anvil.design;
 
 import android.content.res.ColorStateList;
 import android.graphics.PorterDuff;
@@ -26,6 +26,8 @@ import java.lang.CharSequence;
 import java.lang.Float;
 import java.lang.Integer;
 import java.lang.Void;
+import trikita.anvil.Anvil;
+import trikita.anvil.BaseDSL;
 
 /**
  * DSL for creating views and settings their attributes.

--- a/anvil-support-v4/build.gradle
+++ b/anvil-support-v4/build.gradle
@@ -18,7 +18,7 @@ android {
 	}
 
 	defaultConfig {
-		minSdkVersion 7
+		minSdkVersion 10
 		targetSdkVersion 23
 	}
 

--- a/anvil-support-v4/src/main/AndroidManifest.xml
+++ b/anvil-support-v4/src/main/AndroidManifest.xml
@@ -1,2 +1,2 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="trikita.anvil" />
+<manifest package="trikita.anvil.support.v4" />

--- a/anvil-support-v4/src/main/java/trikita/anvil/support/v4/Supportv4DSL.java
+++ b/anvil-support-v4/src/main/java/trikita/anvil/support/v4/Supportv4DSL.java
@@ -1,4 +1,4 @@
-package trikita.anvil;
+package trikita.anvil.support.v4;
 
 import android.graphics.drawable.Drawable;
 import android.support.v4.app.FragmentTabHost;
@@ -19,6 +19,8 @@ import java.lang.Float;
 import java.lang.Integer;
 import java.lang.String;
 import java.lang.Void;
+import trikita.anvil.Anvil;
+import trikita.anvil.BaseDSL;
 
 /**
  * DSL for creating views and settings their attributes.

--- a/buildSrc/src/main/groovy/trikita/anvilgen/AnvilGenPlugin.groovy
+++ b/buildSrc/src/main/groovy/trikita/anvilgen/AnvilGenPlugin.groovy
@@ -66,8 +66,15 @@ public class AnvilGenPlugin implements Plugin<Project> {
             jarFile = getSupportJar(project, libraryName, version)
             dependencies = getSupportDependencies(project, version, rawDeps)
             outputClassName = "${camelCaseName}DSL"
-            packageName = "trikita.anvil"
+            packageName = "trikita.anvil." + dashToDot(libraryName)
         }
+    }
+
+    def dashToDot(libraryName) {
+        if (!libraryName || libraryName.isAllWhitespace()) {
+            return ''
+        }
+        return libraryName.replaceAll("-", ".")
     }
 
     def getSupportDependencies(project, version, Map<String, List<String>> rawDeps) {

--- a/buildSrc/src/main/groovy/trikita/anvilgen/DSLGeneratorTask.groovy
+++ b/buildSrc/src/main/groovy/trikita/anvilgen/DSLGeneratorTask.groovy
@@ -128,7 +128,7 @@ class DSLGeneratorTask extends DefaultTask {
         name = toCase(name, { c -> Character.toLowerCase(c) })
         builder.addMethod(MethodSpec.methodBuilder(name)
                 .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
-                .returns(ClassName.get("trikita.anvil", outputClassName, "ViewClassResult"))
+                .returns(ClassName.get(packageName, outputClassName, "ViewClassResult"))
                 .addStatement("return v(\$T.class)", view)
                 .build())
         builder.addMethod(MethodSpec.methodBuilder(name)


### PR DESCRIPTION
Package names are required to be unique between libraries and not doing
so causes a build error on any app which requires two or more of Anvil's
libraries.

Fix this by ensuring that each library package is suffixed with a
distingushing identifier.