### PR TITLE
anvilgen: stop generating duplicate methods

### DIFF
--- a/anvil-appcompat-v7/src/main/java/trikita/anvil/appcompat/v7/AppCompatv7DSL.java
+++ b/anvil-appcompat-v7/src/main/java/trikita/anvil/appcompat/v7/AppCompatv7DSL.java
@@ -49,7 +49,6 @@ import android.view.MenuItem;
 import android.view.View;
 import android.view.Window;
 import android.widget.PopupWindow;
-import android.widget.SpinnerAdapter;
 import java.lang.Boolean;
 import java.lang.CharSequence;
 import java.lang.Float;
@@ -338,10 +337,6 @@ public final class AppCompatv7DSL {
     return BaseDSL.attr(ActionBarVisibilityCallbackFunccbf3fd1e.instance, arg);
   }
 
-  public static Void adapter(SpinnerAdapter arg) {
-    return BaseDSL.attr(AdapterFunc32a095c1.instance, arg);
-  }
-
   public static Void allowCollapse(boolean arg) {
     return BaseDSL.attr(AllowCollapseFunc148d6054.instance, arg);
   }
@@ -358,32 +353,12 @@ public final class AppCompatv7DSL {
     return BaseDSL.attr(AttachListenerFunc3ca76dcd.instance, arg);
   }
 
-  public static Void backgroundDrawable(Drawable arg) {
-    return BaseDSL.attr(BackgroundDrawableFuncfb47464a.instance, arg);
-  }
-
-  public static Void backgroundResource(int arg) {
-    return BaseDSL.attr(BackgroundResourceFunc8567756a.instance, arg);
-  }
-
   public static Void baselineAligned(boolean arg) {
     return BaseDSL.attr(BaselineAlignedFunc148d6054.instance, arg);
   }
 
   public static Void baselineAlignedChildIndex(int arg) {
     return BaseDSL.attr(BaselineAlignedChildIndexFunc8567756a.instance, arg);
-  }
-
-  public static Void buttonDrawable(Drawable arg) {
-    return BaseDSL.attr(ButtonDrawableFuncfb47464a.instance, arg);
-  }
-
-  public static Void buttonDrawable(int arg) {
-    return BaseDSL.attr(ButtonDrawableFunc8567756a.instance, arg);
-  }
-
-  public static Void checkMarkDrawable(int arg) {
-    return BaseDSL.attr(CheckMarkDrawableFunc8567756a.instance, arg);
   }
 
   public static Void checkable(boolean arg) {
@@ -416,22 +391,6 @@ public final class AppCompatv7DSL {
 
   public static Void dividerPadding(int arg) {
     return BaseDSL.attr(DividerPaddingFunc8567756a.instance, arg);
-  }
-
-  public static Void dropDownBackgroundResource(int arg) {
-    return BaseDSL.attr(DropDownBackgroundResourceFunc8567756a.instance, arg);
-  }
-
-  public static Void dropDownHorizontalOffset(int arg) {
-    return BaseDSL.attr(DropDownHorizontalOffsetFunc8567756a.instance, arg);
-  }
-
-  public static Void dropDownVerticalOffset(int arg) {
-    return BaseDSL.attr(DropDownVerticalOffsetFunc8567756a.instance, arg);
-  }
-
-  public static Void dropDownWidth(int arg) {
-    return BaseDSL.attr(DropDownWidthFunc8567756a.instance, arg);
   }
 
   public static Void expandActivityOverflowButtonContentDescription(int arg) {
@@ -484,10 +443,6 @@ public final class AppCompatv7DSL {
 
   public static Void iconifiedByDefault(boolean arg) {
     return BaseDSL.attr(IconifiedByDefaultFunc148d6054.instance, arg);
-  }
-
-  public static Void imageResource(int arg) {
-    return BaseDSL.attr(ImageResourceFunc8567756a.instance, arg);
   }
 
   public static Void imeOptions(int arg) {
@@ -618,14 +573,6 @@ public final class AppCompatv7DSL {
     return BaseDSL.attr(OverlayModeFunc148d6054.instance, arg);
   }
 
-  public static Void popupBackgroundDrawable(Drawable arg) {
-    return BaseDSL.attr(PopupBackgroundDrawableFuncfb47464a.instance, arg);
-  }
-
-  public static Void popupBackgroundResource(int arg) {
-    return BaseDSL.attr(PopupBackgroundResourceFunc8567756a.instance, arg);
-  }
-
   public static Void popupCallback(ActionMenuItemView.PopupCallback arg) {
     return BaseDSL.attr(PopupCallbackFunc76c77ea5.instance, arg);
   }
@@ -636,10 +583,6 @@ public final class AppCompatv7DSL {
 
   public static Void primaryBackground(Drawable arg) {
     return BaseDSL.attr(PrimaryBackgroundFuncfb47464a.instance, arg);
-  }
-
-  public static Void prompt(CharSequence arg) {
-    return BaseDSL.attr(PromptFuncc0af808b.instance, arg);
   }
 
   public static Void provider(ActionProvider arg) {
@@ -656,10 +599,6 @@ public final class AppCompatv7DSL {
 
   public static Void searchableInfo(SearchableInfo arg) {
     return BaseDSL.attr(SearchableInfoFunc1f96c03c.instance, arg);
-  }
-
-  public static Void selector(Drawable arg) {
-    return BaseDSL.attr(SelectorFuncfb47464a.instance, arg);
   }
 
   public static Void showDividers(int arg) {
@@ -802,10 +741,6 @@ public final class AppCompatv7DSL {
     return BaseDSL.attr(VerticalGravityFunc8567756a.instance, arg);
   }
 
-  public static Void visibility(int arg) {
-    return BaseDSL.attr(VisibilityFunc8567756a.instance, arg);
-  }
-
   public static Void weightSum(float arg) {
     return BaseDSL.attr(WeightSumFunce0893188.instance, arg);
   }
@@ -834,16 +769,6 @@ public final class AppCompatv7DSL {
     public void apply(View v, final ActionBarOverlayLayout.ActionBarVisibilityCallback arg, final ActionBarOverlayLayout.ActionBarVisibilityCallback old) {
       if (v instanceof ActionBarOverlayLayout) {
         ((ActionBarOverlayLayout) v).setActionBarVisibilityCallback(arg);
-      }
-    }
-  }
-
-  private static final class AdapterFunc32a095c1 implements Anvil.AttrFunc<SpinnerAdapter> {
-    public static final AdapterFunc32a095c1 instance = new AdapterFunc32a095c1();
-
-    public void apply(View v, final SpinnerAdapter arg, final SpinnerAdapter old) {
-      if (v instanceof AppCompatSpinner) {
-        ((AppCompatSpinner) v).setAdapter(arg);
       }
     }
   }
@@ -888,68 +813,6 @@ public final class AppCompatv7DSL {
     }
   }
 
-  private static final class BackgroundDrawableFuncfb47464a implements Anvil.AttrFunc<Drawable> {
-    public static final BackgroundDrawableFuncfb47464a instance = new BackgroundDrawableFuncfb47464a();
-
-    public void apply(View v, final Drawable arg, final Drawable old) {
-      if (v instanceof AppCompatAutoCompleteTextView) {
-        ((AppCompatAutoCompleteTextView) v).setBackgroundDrawable(arg);
-      }
-      if (v instanceof AppCompatButton) {
-        ((AppCompatButton) v).setBackgroundDrawable(arg);
-      }
-      if (v instanceof AppCompatEditText) {
-        ((AppCompatEditText) v).setBackgroundDrawable(arg);
-      }
-      if (v instanceof AppCompatImageButton) {
-        ((AppCompatImageButton) v).setBackgroundDrawable(arg);
-      }
-      if (v instanceof AppCompatImageView) {
-        ((AppCompatImageView) v).setBackgroundDrawable(arg);
-      }
-      if (v instanceof AppCompatMultiAutoCompleteTextView) {
-        ((AppCompatMultiAutoCompleteTextView) v).setBackgroundDrawable(arg);
-      }
-      if (v instanceof AppCompatSpinner) {
-        ((AppCompatSpinner) v).setBackgroundDrawable(arg);
-      }
-      if (v instanceof AppCompatTextView) {
-        ((AppCompatTextView) v).setBackgroundDrawable(arg);
-      }
-    }
-  }
-
-  private static final class BackgroundResourceFunc8567756a implements Anvil.AttrFunc<Integer> {
-    public static final BackgroundResourceFunc8567756a instance = new BackgroundResourceFunc8567756a();
-
-    public void apply(View v, final Integer arg, final Integer old) {
-      if (v instanceof AppCompatAutoCompleteTextView) {
-        ((AppCompatAutoCompleteTextView) v).setBackgroundResource(arg);
-      }
-      if (v instanceof AppCompatButton) {
-        ((AppCompatButton) v).setBackgroundResource(arg);
-      }
-      if (v instanceof AppCompatEditText) {
-        ((AppCompatEditText) v).setBackgroundResource(arg);
-      }
-      if (v instanceof AppCompatImageButton) {
-        ((AppCompatImageButton) v).setBackgroundResource(arg);
-      }
-      if (v instanceof AppCompatImageView) {
-        ((AppCompatImageView) v).setBackgroundResource(arg);
-      }
-      if (v instanceof AppCompatMultiAutoCompleteTextView) {
-        ((AppCompatMultiAutoCompleteTextView) v).setBackgroundResource(arg);
-      }
-      if (v instanceof AppCompatSpinner) {
-        ((AppCompatSpinner) v).setBackgroundResource(arg);
-      }
-      if (v instanceof AppCompatTextView) {
-        ((AppCompatTextView) v).setBackgroundResource(arg);
-      }
-    }
-  }
-
   private static final class BaselineAlignedFunc148d6054 implements Anvil.AttrFunc<Boolean> {
     public static final BaselineAlignedFunc148d6054 instance = new BaselineAlignedFunc148d6054();
 
@@ -966,42 +829,6 @@ public final class AppCompatv7DSL {
     public void apply(View v, final Integer arg, final Integer old) {
       if (v instanceof LinearLayoutCompat) {
         ((LinearLayoutCompat) v).setBaselineAlignedChildIndex(arg);
-      }
-    }
-  }
-
-  private static final class ButtonDrawableFuncfb47464a implements Anvil.AttrFunc<Drawable> {
-    public static final ButtonDrawableFuncfb47464a instance = new ButtonDrawableFuncfb47464a();
-
-    public void apply(View v, final Drawable arg, final Drawable old) {
-      if (v instanceof AppCompatCheckBox) {
-        ((AppCompatCheckBox) v).setButtonDrawable(arg);
-      }
-      if (v instanceof AppCompatRadioButton) {
-        ((AppCompatRadioButton) v).setButtonDrawable(arg);
-      }
-    }
-  }
-
-  private static final class ButtonDrawableFunc8567756a implements Anvil.AttrFunc<Integer> {
-    public static final ButtonDrawableFunc8567756a instance = new ButtonDrawableFunc8567756a();
-
-    public void apply(View v, final Integer arg, final Integer old) {
-      if (v instanceof AppCompatCheckBox) {
-        ((AppCompatCheckBox) v).setButtonDrawable(arg);
-      }
-      if (v instanceof AppCompatRadioButton) {
-        ((AppCompatRadioButton) v).setButtonDrawable(arg);
-      }
-    }
-  }
-
-  private static final class CheckMarkDrawableFunc8567756a implements Anvil.AttrFunc<Integer> {
-    public static final CheckMarkDrawableFunc8567756a instance = new CheckMarkDrawableFunc8567756a();
-
-    public void apply(View v, final Integer arg, final Integer old) {
-      if (v instanceof AppCompatCheckedTextView) {
-        ((AppCompatCheckedTextView) v).setCheckMarkDrawable(arg);
       }
     }
   }
@@ -1029,9 +856,6 @@ public final class AppCompatv7DSL {
       if (v instanceof ListMenuItemView) {
         ((ListMenuItemView) v).setChecked(arg);
       }
-      if (v instanceof SwitchCompat) {
-        ((SwitchCompat) v).setChecked(arg);
-      }
     }
   }
 
@@ -1049,9 +873,6 @@ public final class AppCompatv7DSL {
     public static final ContentHeightFunc8567756a instance = new ContentHeightFunc8567756a();
 
     public void apply(View v, final Integer arg, final Integer old) {
-      if (v instanceof ActionBarContextView) {
-        ((ActionBarContextView) v).setContentHeight(arg);
-      }
       if (v instanceof ScrollingTabContainerView) {
         ((ScrollingTabContainerView) v).setContentHeight(arg);
       }
@@ -1094,49 +915,6 @@ public final class AppCompatv7DSL {
     public void apply(View v, final Integer arg, final Integer old) {
       if (v instanceof LinearLayoutCompat) {
         ((LinearLayoutCompat) v).setDividerPadding(arg);
-      }
-    }
-  }
-
-  private static final class DropDownBackgroundResourceFunc8567756a implements Anvil.AttrFunc<Integer> {
-    public static final DropDownBackgroundResourceFunc8567756a instance = new DropDownBackgroundResourceFunc8567756a();
-
-    public void apply(View v, final Integer arg, final Integer old) {
-      if (v instanceof AppCompatAutoCompleteTextView) {
-        ((AppCompatAutoCompleteTextView) v).setDropDownBackgroundResource(arg);
-      }
-      if (v instanceof AppCompatMultiAutoCompleteTextView) {
-        ((AppCompatMultiAutoCompleteTextView) v).setDropDownBackgroundResource(arg);
-      }
-    }
-  }
-
-  private static final class DropDownHorizontalOffsetFunc8567756a implements Anvil.AttrFunc<Integer> {
-    public static final DropDownHorizontalOffsetFunc8567756a instance = new DropDownHorizontalOffsetFunc8567756a();
-
-    public void apply(View v, final Integer arg, final Integer old) {
-      if (v instanceof AppCompatSpinner) {
-        ((AppCompatSpinner) v).setDropDownHorizontalOffset(arg);
-      }
-    }
-  }
-
-  private static final class DropDownVerticalOffsetFunc8567756a implements Anvil.AttrFunc<Integer> {
-    public static final DropDownVerticalOffsetFunc8567756a instance = new DropDownVerticalOffsetFunc8567756a();
-
-    public void apply(View v, final Integer arg, final Integer old) {
-      if (v instanceof AppCompatSpinner) {
-        ((AppCompatSpinner) v).setDropDownVerticalOffset(arg);
-      }
-    }
-  }
-
-  private static final class DropDownWidthFunc8567756a implements Anvil.AttrFunc<Integer> {
-    public static final DropDownWidthFunc8567756a instance = new DropDownWidthFunc8567756a();
-
-    public void apply(View v, final Integer arg, final Integer old) {
-      if (v instanceof AppCompatSpinner) {
-        ((AppCompatSpinner) v).setDropDownWidth(arg);
       }
     }
   }
@@ -1273,19 +1051,6 @@ public final class AppCompatv7DSL {
     public void apply(View v, final Boolean arg, final Boolean old) {
       if (v instanceof SearchView) {
         ((SearchView) v).setIconifiedByDefault(arg);
-      }
-    }
-  }
-
-  private static final class ImageResourceFunc8567756a implements Anvil.AttrFunc<Integer> {
-    public static final ImageResourceFunc8567756a instance = new ImageResourceFunc8567756a();
-
-    public void apply(View v, final Integer arg, final Integer old) {
-      if (v instanceof AppCompatImageButton) {
-        ((AppCompatImageButton) v).setImageResource(arg);
-      }
-      if (v instanceof AppCompatImageView) {
-        ((AppCompatImageView) v).setImageResource(arg);
       }
     }
   }
@@ -1735,26 +1500,6 @@ public final class AppCompatv7DSL {
     }
   }
 
-  private static final class PopupBackgroundDrawableFuncfb47464a implements Anvil.AttrFunc<Drawable> {
-    public static final PopupBackgroundDrawableFuncfb47464a instance = new PopupBackgroundDrawableFuncfb47464a();
-
-    public void apply(View v, final Drawable arg, final Drawable old) {
-      if (v instanceof AppCompatSpinner) {
-        ((AppCompatSpinner) v).setPopupBackgroundDrawable(arg);
-      }
-    }
-  }
-
-  private static final class PopupBackgroundResourceFunc8567756a implements Anvil.AttrFunc<Integer> {
-    public static final PopupBackgroundResourceFunc8567756a instance = new PopupBackgroundResourceFunc8567756a();
-
-    public void apply(View v, final Integer arg, final Integer old) {
-      if (v instanceof AppCompatSpinner) {
-        ((AppCompatSpinner) v).setPopupBackgroundResource(arg);
-      }
-    }
-  }
-
   private static final class PopupCallbackFunc76c77ea5 implements Anvil.AttrFunc<ActionMenuItemView.PopupCallback> {
     public static final PopupCallbackFunc76c77ea5 instance = new PopupCallbackFunc76c77ea5();
 
@@ -1784,16 +1529,6 @@ public final class AppCompatv7DSL {
     public void apply(View v, final Drawable arg, final Drawable old) {
       if (v instanceof ActionBarContainer) {
         ((ActionBarContainer) v).setPrimaryBackground(arg);
-      }
-    }
-  }
-
-  private static final class PromptFuncc0af808b implements Anvil.AttrFunc<CharSequence> {
-    public static final PromptFuncc0af808b instance = new PromptFuncc0af808b();
-
-    public void apply(View v, final CharSequence arg, final CharSequence old) {
-      if (v instanceof AppCompatSpinner) {
-        ((AppCompatSpinner) v).setPrompt(arg);
       }
     }
   }
@@ -1834,16 +1569,6 @@ public final class AppCompatv7DSL {
     public void apply(View v, final SearchableInfo arg, final SearchableInfo old) {
       if (v instanceof SearchView) {
         ((SearchView) v).setSearchableInfo(arg);
-      }
-    }
-  }
-
-  private static final class SelectorFuncfb47464a implements Anvil.AttrFunc<Drawable> {
-    public static final SelectorFuncfb47464a instance = new SelectorFuncfb47464a();
-
-    public void apply(View v, final Drawable arg, final Drawable old) {
-      if (v instanceof ListViewCompat) {
-        ((ListViewCompat) v).setSelector(arg);
       }
     }
   }
@@ -2254,19 +1979,6 @@ public final class AppCompatv7DSL {
     public void apply(View v, final Integer arg, final Integer old) {
       if (v instanceof LinearLayoutCompat) {
         ((LinearLayoutCompat) v).setVerticalGravity(arg);
-      }
-    }
-  }
-
-  private static final class VisibilityFunc8567756a implements Anvil.AttrFunc<Integer> {
-    public static final VisibilityFunc8567756a instance = new VisibilityFunc8567756a();
-
-    public void apply(View v, final Integer arg, final Integer old) {
-      if (v instanceof ActionBarContainer) {
-        ((ActionBarContainer) v).setVisibility(arg);
-      }
-      if (v instanceof ViewStubCompat) {
-        ((ViewStubCompat) v).setVisibility(arg);
       }
     }
   }

--- a/anvil-design/src/main/java/trikita/anvil/design/DesignDSL.java
+++ b/anvil-design/src/main/java/trikita/anvil/design/DesignDSL.java
@@ -17,10 +17,8 @@ import android.support.design.widget.TabItem;
 import android.support.design.widget.TabLayout;
 import android.support.design.widget.TextInputEditText;
 import android.support.design.widget.TextInputLayout;
-import android.support.v4.view.PagerAdapter;
 import android.support.v4.view.ViewPager;
 import android.view.View;
-import android.view.ViewGroup;
 import java.lang.Boolean;
 import java.lang.CharSequence;
 import java.lang.Float;
@@ -138,18 +136,6 @@ public final class DesignDSL {
 
   public static Void textInputLayout(Anvil.Renderable r) {
     return BaseDSL.v(TextInputLayout.class, r);
-  }
-
-  public static Void backgroundColor(int arg) {
-    return BaseDSL.attr(BackgroundColorFunc8567756a.instance, arg);
-  }
-
-  public static Void backgroundDrawable(Drawable arg) {
-    return BaseDSL.attr(BackgroundDrawableFuncfb47464a.instance, arg);
-  }
-
-  public static Void backgroundResource(int arg) {
-    return BaseDSL.attr(BackgroundResourceFunc8567756a.instance, arg);
   }
 
   public static Void backgroundTintList(ColorStateList arg) {
@@ -284,10 +270,6 @@ public final class DesignDSL {
     return BaseDSL.attr(IconFuncfb47464a.instance, arg);
   }
 
-  public static Void imageResource(int arg) {
-    return BaseDSL.attr(ImageResourceFunc8567756a.instance, arg);
-  }
-
   public static Void itemBackground(Drawable arg) {
     return BaseDSL.attr(ItemBackgroundFuncfb47464a.instance, arg);
   }
@@ -312,16 +294,8 @@ public final class DesignDSL {
     return BaseDSL.attr(NavigationItemSelectedListenerFunc80db0872.instance, arg);
   }
 
-  public static Void onHierarchyChange(ViewGroup.OnHierarchyChangeListener arg) {
-    return BaseDSL.attr(OnHierarchyChangeFunc7b5dc8bc.instance, arg);
-  }
-
   public static Void onTabSelected(TabLayout.OnTabSelectedListener arg) {
     return BaseDSL.attr(OnTabSelectedFuncaa1c085e.instance, arg);
-  }
-
-  public static Void orientation(int arg) {
-    return BaseDSL.attr(OrientationFunc8567756a.instance, arg);
   }
 
   public static Void rippleColor(int arg) {
@@ -376,10 +350,6 @@ public final class DesignDSL {
     return BaseDSL.attr(TabTextColorsFunc9e5e0e4e.instance, arg);
   }
 
-  public static Void tabsFromPagerAdapter(PagerAdapter arg) {
-    return BaseDSL.attr(TabsFromPagerAdapterFuncdc294743.instance, arg);
-  }
-
   public static Void targetElevation(float arg) {
     return BaseDSL.attr(TargetElevationFunce0893188.instance, arg);
   }
@@ -406,40 +376,6 @@ public final class DesignDSL {
 
   public static Void useCompatPadding(boolean arg) {
     return BaseDSL.attr(UseCompatPaddingFunc148d6054.instance, arg);
-  }
-
-  public static Void visibility(int arg) {
-    return BaseDSL.attr(VisibilityFunc8567756a.instance, arg);
-  }
-
-  private static final class BackgroundColorFunc8567756a implements Anvil.AttrFunc<Integer> {
-    public static final BackgroundColorFunc8567756a instance = new BackgroundColorFunc8567756a();
-
-    public void apply(View v, final Integer arg, final Integer old) {
-      if (v instanceof FloatingActionButton) {
-        ((FloatingActionButton) v).setBackgroundColor(arg);
-      }
-    }
-  }
-
-  private static final class BackgroundDrawableFuncfb47464a implements Anvil.AttrFunc<Drawable> {
-    public static final BackgroundDrawableFuncfb47464a instance = new BackgroundDrawableFuncfb47464a();
-
-    public void apply(View v, final Drawable arg, final Drawable old) {
-      if (v instanceof FloatingActionButton) {
-        ((FloatingActionButton) v).setBackgroundDrawable(arg);
-      }
-    }
-  }
-
-  private static final class BackgroundResourceFunc8567756a implements Anvil.AttrFunc<Integer> {
-    public static final BackgroundResourceFunc8567756a instance = new BackgroundResourceFunc8567756a();
-
-    public void apply(View v, final Integer arg, final Integer old) {
-      if (v instanceof FloatingActionButton) {
-        ((FloatingActionButton) v).setBackgroundResource(arg);
-      }
-    }
   }
 
   private static final class BackgroundTintListFunc9e5e0e4e implements Anvil.AttrFunc<ColorStateList> {
@@ -772,16 +708,6 @@ public final class DesignDSL {
     }
   }
 
-  private static final class ImageResourceFunc8567756a implements Anvil.AttrFunc<Integer> {
-    public static final ImageResourceFunc8567756a instance = new ImageResourceFunc8567756a();
-
-    public void apply(View v, final Integer arg, final Integer old) {
-      if (v instanceof FloatingActionButton) {
-        ((FloatingActionButton) v).setImageResource(arg);
-      }
-    }
-  }
-
   private static final class ItemBackgroundFuncfb47464a implements Anvil.AttrFunc<Drawable> {
     public static final ItemBackgroundFuncfb47464a instance = new ItemBackgroundFuncfb47464a();
 
@@ -842,30 +768,6 @@ public final class DesignDSL {
     }
   }
 
-  private static final class OnHierarchyChangeFunc7b5dc8bc implements Anvil.AttrFunc<ViewGroup.OnHierarchyChangeListener> {
-    public static final OnHierarchyChangeFunc7b5dc8bc instance = new OnHierarchyChangeFunc7b5dc8bc();
-
-    public void apply(View v, final ViewGroup.OnHierarchyChangeListener arg, final ViewGroup.OnHierarchyChangeListener old) {
-      if (v instanceof CoordinatorLayout) {
-        if (arg != null) {
-          ((CoordinatorLayout) v).setOnHierarchyChangeListener(new ViewGroup.OnHierarchyChangeListener() {
-            public void onChildViewAdded(View a0, View a1) {
-              arg.onChildViewAdded(a0, a1);
-              Anvil.render();
-            }
-
-            public void onChildViewRemoved(View a0, View a1) {
-              arg.onChildViewRemoved(a0, a1);
-              Anvil.render();
-            }
-          });
-        } else {
-          ((CoordinatorLayout) v).setOnHierarchyChangeListener((ViewGroup.OnHierarchyChangeListener) null);
-        }
-      }
-    }
-  }
-
   private static final class OnTabSelectedFuncaa1c085e implements Anvil.AttrFunc<TabLayout.OnTabSelectedListener> {
     public static final OnTabSelectedFuncaa1c085e instance = new OnTabSelectedFuncaa1c085e();
 
@@ -891,16 +793,6 @@ public final class DesignDSL {
         } else {
           ((TabLayout) v).setOnTabSelectedListener((TabLayout.OnTabSelectedListener) null);
         }
-      }
-    }
-  }
-
-  private static final class OrientationFunc8567756a implements Anvil.AttrFunc<Integer> {
-    public static final OrientationFunc8567756a instance = new OrientationFunc8567756a();
-
-    public void apply(View v, final Integer arg, final Integer old) {
-      if (v instanceof AppBarLayout) {
-        ((AppBarLayout) v).setOrientation(arg);
       }
     }
   }
@@ -1035,16 +927,6 @@ public final class DesignDSL {
     }
   }
 
-  private static final class TabsFromPagerAdapterFuncdc294743 implements Anvil.AttrFunc<PagerAdapter> {
-    public static final TabsFromPagerAdapterFuncdc294743 instance = new TabsFromPagerAdapterFuncdc294743();
-
-    public void apply(View v, final PagerAdapter arg, final PagerAdapter old) {
-      if (v instanceof TabLayout) {
-        ((TabLayout) v).setTabsFromPagerAdapter(arg);
-      }
-    }
-  }
-
   private static final class TargetElevationFunce0893188 implements Anvil.AttrFunc<Float> {
     public static final TargetElevationFunce0893188 instance = new TargetElevationFunce0893188();
 
@@ -1114,19 +996,6 @@ public final class DesignDSL {
     public void apply(View v, final Boolean arg, final Boolean old) {
       if (v instanceof FloatingActionButton) {
         ((FloatingActionButton) v).setUseCompatPadding(arg);
-      }
-    }
-  }
-
-  private static final class VisibilityFunc8567756a implements Anvil.AttrFunc<Integer> {
-    public static final VisibilityFunc8567756a instance = new VisibilityFunc8567756a();
-
-    public void apply(View v, final Integer arg, final Integer old) {
-      if (v instanceof CollapsingToolbarLayout) {
-        ((CollapsingToolbarLayout) v).setVisibility(arg);
-      }
-      if (v instanceof CoordinatorLayout) {
-        ((CoordinatorLayout) v).setVisibility(arg);
       }
     }
   }

--- a/anvil-support-v4/src/main/java/trikita/anvil/support/v4/Supportv4DSL.java
+++ b/anvil-support-v4/src/main/java/trikita/anvil/support/v4/Supportv4DSL.java
@@ -13,11 +13,9 @@ import android.support.v4.widget.SlidingPaneLayout;
 import android.support.v4.widget.Space;
 import android.support.v4.widget.SwipeRefreshLayout;
 import android.view.View;
-import android.widget.TabHost;
 import java.lang.Boolean;
 import java.lang.Float;
 import java.lang.Integer;
-import java.lang.String;
 import java.lang.Void;
 import trikita.anvil.Anvil;
 import trikita.anvil.BaseDSL;
@@ -113,22 +111,6 @@ public final class Supportv4DSL {
     return BaseDSL.attr(AdapterFuncdc294743.instance, arg);
   }
 
-  public static Void backgroundColor(int arg) {
-    return BaseDSL.attr(BackgroundColorFunc8567756a.instance, arg);
-  }
-
-  public static Void backgroundDrawable(Drawable arg) {
-    return BaseDSL.attr(BackgroundDrawableFuncfb47464a.instance, arg);
-  }
-
-  public static Void backgroundResource(int arg) {
-    return BaseDSL.attr(BackgroundResourceFunc8567756a.instance, arg);
-  }
-
-  public static Void colorScheme(int[] arg) {
-    return BaseDSL.attr(ColorSchemeFunc5fb6391.instance, arg);
-  }
-
   public static Void colorSchemeColors(int[] arg) {
     return BaseDSL.attr(ColorSchemeColorsFunc5fb6391.instance, arg);
   }
@@ -157,10 +139,6 @@ public final class Supportv4DSL {
     return BaseDSL.attr(DrawerElevationFunce0893188.instance, arg);
   }
 
-  public static Void drawerListener(DrawerLayout.DrawerListener arg) {
-    return BaseDSL.attr(DrawerListenerFunc17bd5440.instance, arg);
-  }
-
   public static Void drawerLockMode(int arg) {
     return BaseDSL.attr(DrawerLockModeFunc8567756a.instance, arg);
   }
@@ -185,20 +163,12 @@ public final class Supportv4DSL {
     return BaseDSL.attr(OffscreenPageLimitFunc8567756a.instance, arg);
   }
 
-  public static Void onPageChange(ViewPager.OnPageChangeListener arg) {
-    return BaseDSL.attr(OnPageChangeFunc248abe99.instance, arg);
-  }
-
   public static Void onRefresh(SwipeRefreshLayout.OnRefreshListener arg) {
     return BaseDSL.attr(OnRefreshFunc6ab1eac5.instance, arg);
   }
 
   public static Void onScrollChange(NestedScrollView.OnScrollChangeListener arg) {
     return BaseDSL.attr(OnScrollChangeFunc220ef5fd.instance, arg);
-  }
-
-  public static Void onTabChanged(TabHost.OnTabChangeListener arg) {
-    return BaseDSL.attr(OnTabChangedFunc2d645be.instance, arg);
   }
 
   public static Void pageMargin(int arg) {
@@ -221,10 +191,6 @@ public final class Supportv4DSL {
     return BaseDSL.attr(ParallaxDistanceFunc8567756a.instance, arg);
   }
 
-  public static Void progressBackgroundColor(int arg) {
-    return BaseDSL.attr(ProgressBackgroundColorFunc8567756a.instance, arg);
-  }
-
   public static Void progressBackgroundColorSchemeColor(int arg) {
     return BaseDSL.attr(ProgressBackgroundColorSchemeColorFunc8567756a.instance, arg);
   }
@@ -241,20 +207,12 @@ public final class Supportv4DSL {
     return BaseDSL.attr(ScrimColorFunc8567756a.instance, arg);
   }
 
-  public static Void shadowDrawable(Drawable arg) {
-    return BaseDSL.attr(ShadowDrawableFuncfb47464a.instance, arg);
-  }
-
   public static Void shadowDrawableLeft(Drawable arg) {
     return BaseDSL.attr(ShadowDrawableLeftFuncfb47464a.instance, arg);
   }
 
   public static Void shadowDrawableRight(Drawable arg) {
     return BaseDSL.attr(ShadowDrawableRightFuncfb47464a.instance, arg);
-  }
-
-  public static Void shadowResource(int arg) {
-    return BaseDSL.attr(ShadowResourceFunc8567756a.instance, arg);
   }
 
   public static Void shadowResourceLeft(int arg) {
@@ -311,46 +269,6 @@ public final class Supportv4DSL {
     public void apply(View v, final PagerAdapter arg, final PagerAdapter old) {
       if (v instanceof ViewPager) {
         ((ViewPager) v).setAdapter(arg);
-      }
-    }
-  }
-
-  private static final class BackgroundColorFunc8567756a implements Anvil.AttrFunc<Integer> {
-    public static final BackgroundColorFunc8567756a instance = new BackgroundColorFunc8567756a();
-
-    public void apply(View v, final Integer arg, final Integer old) {
-      if (v instanceof PagerTabStrip) {
-        ((PagerTabStrip) v).setBackgroundColor(arg);
-      }
-    }
-  }
-
-  private static final class BackgroundDrawableFuncfb47464a implements Anvil.AttrFunc<Drawable> {
-    public static final BackgroundDrawableFuncfb47464a instance = new BackgroundDrawableFuncfb47464a();
-
-    public void apply(View v, final Drawable arg, final Drawable old) {
-      if (v instanceof PagerTabStrip) {
-        ((PagerTabStrip) v).setBackgroundDrawable(arg);
-      }
-    }
-  }
-
-  private static final class BackgroundResourceFunc8567756a implements Anvil.AttrFunc<Integer> {
-    public static final BackgroundResourceFunc8567756a instance = new BackgroundResourceFunc8567756a();
-
-    public void apply(View v, final Integer arg, final Integer old) {
-      if (v instanceof PagerTabStrip) {
-        ((PagerTabStrip) v).setBackgroundResource(arg);
-      }
-    }
-  }
-
-  private static final class ColorSchemeFunc5fb6391 implements Anvil.AttrFunc<int[]> {
-    public static final ColorSchemeFunc5fb6391 instance = new ColorSchemeFunc5fb6391();
-
-    public void apply(View v, final int[] arg, final int[] old) {
-      if (v instanceof SwipeRefreshLayout) {
-        ((SwipeRefreshLayout) v).setColorScheme(arg);
       }
     }
   }
@@ -425,16 +343,6 @@ public final class Supportv4DSL {
     }
   }
 
-  private static final class DrawerListenerFunc17bd5440 implements Anvil.AttrFunc<DrawerLayout.DrawerListener> {
-    public static final DrawerListenerFunc17bd5440 instance = new DrawerListenerFunc17bd5440();
-
-    public void apply(View v, final DrawerLayout.DrawerListener arg, final DrawerLayout.DrawerListener old) {
-      if (v instanceof DrawerLayout) {
-        ((DrawerLayout) v).setDrawerListener(arg);
-      }
-    }
-  }
-
   private static final class DrawerLockModeFunc8567756a implements Anvil.AttrFunc<Integer> {
     public static final DrawerLockModeFunc8567756a instance = new DrawerLockModeFunc8567756a();
 
@@ -498,35 +406,6 @@ public final class Supportv4DSL {
     }
   }
 
-  private static final class OnPageChangeFunc248abe99 implements Anvil.AttrFunc<ViewPager.OnPageChangeListener> {
-    public static final OnPageChangeFunc248abe99 instance = new OnPageChangeFunc248abe99();
-
-    public void apply(View v, final ViewPager.OnPageChangeListener arg, final ViewPager.OnPageChangeListener old) {
-      if (v instanceof ViewPager) {
-        if (arg != null) {
-          ((ViewPager) v).setOnPageChangeListener(new ViewPager.OnPageChangeListener() {
-            public void onPageScrollStateChanged(int a0) {
-              arg.onPageScrollStateChanged(a0);
-              Anvil.render();
-            }
-
-            public void onPageScrolled(int a0, float a1, int a2) {
-              arg.onPageScrolled(a0, a1, a2);
-              Anvil.render();
-            }
-
-            public void onPageSelected(int a0) {
-              arg.onPageSelected(a0);
-              Anvil.render();
-            }
-          });
-        } else {
-          ((ViewPager) v).setOnPageChangeListener((ViewPager.OnPageChangeListener) null);
-        }
-      }
-    }
-  }
-
   private static final class OnRefreshFunc6ab1eac5 implements Anvil.AttrFunc<SwipeRefreshLayout.OnRefreshListener> {
     public static final OnRefreshFunc6ab1eac5 instance = new OnRefreshFunc6ab1eac5();
 
@@ -560,25 +439,6 @@ public final class Supportv4DSL {
           });
         } else {
           ((NestedScrollView) v).setOnScrollChangeListener((NestedScrollView.OnScrollChangeListener) null);
-        }
-      }
-    }
-  }
-
-  private static final class OnTabChangedFunc2d645be implements Anvil.AttrFunc<TabHost.OnTabChangeListener> {
-    public static final OnTabChangedFunc2d645be instance = new OnTabChangedFunc2d645be();
-
-    public void apply(View v, final TabHost.OnTabChangeListener arg, final TabHost.OnTabChangeListener old) {
-      if (v instanceof FragmentTabHost) {
-        if (arg != null) {
-          ((FragmentTabHost) v).setOnTabChangedListener(new TabHost.OnTabChangeListener() {
-            public void onTabChanged(String a0) {
-              arg.onTabChanged(a0);
-              Anvil.render();
-            }
-          });
-        } else {
-          ((FragmentTabHost) v).setOnTabChangedListener((TabHost.OnTabChangeListener) null);
         }
       }
     }
@@ -634,16 +494,6 @@ public final class Supportv4DSL {
     }
   }
 
-  private static final class ProgressBackgroundColorFunc8567756a implements Anvil.AttrFunc<Integer> {
-    public static final ProgressBackgroundColorFunc8567756a instance = new ProgressBackgroundColorFunc8567756a();
-
-    public void apply(View v, final Integer arg, final Integer old) {
-      if (v instanceof SwipeRefreshLayout) {
-        ((SwipeRefreshLayout) v).setProgressBackgroundColor(arg);
-      }
-    }
-  }
-
   private static final class ProgressBackgroundColorSchemeColorFunc8567756a implements Anvil.AttrFunc<Integer> {
     public static final ProgressBackgroundColorSchemeColorFunc8567756a instance = new ProgressBackgroundColorSchemeColorFunc8567756a();
 
@@ -684,16 +534,6 @@ public final class Supportv4DSL {
     }
   }
 
-  private static final class ShadowDrawableFuncfb47464a implements Anvil.AttrFunc<Drawable> {
-    public static final ShadowDrawableFuncfb47464a instance = new ShadowDrawableFuncfb47464a();
-
-    public void apply(View v, final Drawable arg, final Drawable old) {
-      if (v instanceof SlidingPaneLayout) {
-        ((SlidingPaneLayout) v).setShadowDrawable(arg);
-      }
-    }
-  }
-
   private static final class ShadowDrawableLeftFuncfb47464a implements Anvil.AttrFunc<Drawable> {
     public static final ShadowDrawableLeftFuncfb47464a instance = new ShadowDrawableLeftFuncfb47464a();
 
@@ -710,16 +550,6 @@ public final class Supportv4DSL {
     public void apply(View v, final Drawable arg, final Drawable old) {
       if (v instanceof SlidingPaneLayout) {
         ((SlidingPaneLayout) v).setShadowDrawableRight(arg);
-      }
-    }
-  }
-
-  private static final class ShadowResourceFunc8567756a implements Anvil.AttrFunc<Integer> {
-    public static final ShadowResourceFunc8567756a instance = new ShadowResourceFunc8567756a();
-
-    public void apply(View v, final Integer arg, final Integer old) {
-      if (v instanceof SlidingPaneLayout) {
-        ((SlidingPaneLayout) v).setShadowResource(arg);
       }
     }
   }
@@ -838,9 +668,6 @@ public final class Supportv4DSL {
     public static final TextSpacingFunc8567756a instance = new TextSpacingFunc8567756a();
 
     public void apply(View v, final Integer arg, final Integer old) {
-      if (v instanceof PagerTabStrip) {
-        ((PagerTabStrip) v).setTextSpacing(arg);
-      }
       if (v instanceof PagerTitleStrip) {
         ((PagerTitleStrip) v).setTextSpacing(arg);
       }

--- a/anvil/src/sdk10/java/trikita/anvil/DSL.java
+++ b/anvil/src/sdk10/java/trikita/anvil/DSL.java
@@ -2070,9 +2070,6 @@ public final class DSL extends BaseDSL {
       if (v instanceof AbsListView) {
         ((AbsListView) v).setCacheColorHint(arg);
       }
-      if (v instanceof ListView) {
-        ((ListView) v).setCacheColorHint(arg);
-      }
     }
   }
 
@@ -2125,9 +2122,6 @@ public final class DSL extends BaseDSL {
       }
       if (v instanceof CompoundButton) {
         ((CompoundButton) v).setChecked(arg);
-      }
-      if (v instanceof ToggleButton) {
-        ((ToggleButton) v).setChecked(arg);
       }
     }
   }
@@ -2577,9 +2571,6 @@ public final class DSL extends BaseDSL {
     public static final EllipsizeFunc63cb4885 instance = new EllipsizeFunc63cb4885();
 
     public void apply(View v, final TextUtils.TruncateAt arg, final TextUtils.TruncateAt old) {
-      if (v instanceof EditText) {
-        ((EditText) v).setEllipsize(arg);
-      }
       if (v instanceof TextView) {
         ((TextView) v).setEllipsize(arg);
       }
@@ -2648,9 +2639,6 @@ public final class DSL extends BaseDSL {
     public static final ExtractedTextFunc410b6fe0 instance = new ExtractedTextFunc410b6fe0();
 
     public void apply(View v, final ExtractedText arg, final ExtractedText old) {
-      if (v instanceof ExtractEditText) {
-        ((ExtractEditText) v).setExtractedText(arg);
-      }
       if (v instanceof TextView) {
         ((TextView) v).setExtractedText(arg);
       }
@@ -3521,14 +3509,8 @@ public final class DSL extends BaseDSL {
     public static final MaxFunc8567756a instance = new MaxFunc8567756a();
 
     public void apply(View v, final Integer arg, final Integer old) {
-      if (v instanceof AbsSeekBar) {
-        ((AbsSeekBar) v).setMax(arg);
-      }
       if (v instanceof ProgressBar) {
         ((ProgressBar) v).setMax(arg);
-      }
-      if (v instanceof RatingBar) {
-        ((RatingBar) v).setMax(arg);
       }
     }
   }
@@ -4078,57 +4060,6 @@ public final class DSL extends BaseDSL {
           ((ViewGroup) v).setOnHierarchyChangeListener((ViewGroup.OnHierarchyChangeListener) null);
         }
       }
-      if (v instanceof RadioGroup) {
-        if (arg != null) {
-          ((RadioGroup) v).setOnHierarchyChangeListener(new ViewGroup.OnHierarchyChangeListener() {
-            public void onChildViewAdded(View a0, View a1) {
-              arg.onChildViewAdded(a0, a1);
-              Anvil.render();
-            }
-
-            public void onChildViewRemoved(View a0, View a1) {
-              arg.onChildViewRemoved(a0, a1);
-              Anvil.render();
-            }
-          });
-        } else {
-          ((RadioGroup) v).setOnHierarchyChangeListener((ViewGroup.OnHierarchyChangeListener) null);
-        }
-      }
-      if (v instanceof TableLayout) {
-        if (arg != null) {
-          ((TableLayout) v).setOnHierarchyChangeListener(new ViewGroup.OnHierarchyChangeListener() {
-            public void onChildViewAdded(View a0, View a1) {
-              arg.onChildViewAdded(a0, a1);
-              Anvil.render();
-            }
-
-            public void onChildViewRemoved(View a0, View a1) {
-              arg.onChildViewRemoved(a0, a1);
-              Anvil.render();
-            }
-          });
-        } else {
-          ((TableLayout) v).setOnHierarchyChangeListener((ViewGroup.OnHierarchyChangeListener) null);
-        }
-      }
-      if (v instanceof TableRow) {
-        if (arg != null) {
-          ((TableRow) v).setOnHierarchyChangeListener(new ViewGroup.OnHierarchyChangeListener() {
-            public void onChildViewAdded(View a0, View a1) {
-              arg.onChildViewAdded(a0, a1);
-              Anvil.render();
-            }
-
-            public void onChildViewRemoved(View a0, View a1) {
-              arg.onChildViewRemoved(a0, a1);
-              Anvil.render();
-            }
-          });
-        } else {
-          ((TableRow) v).setOnHierarchyChangeListener((ViewGroup.OnHierarchyChangeListener) null);
-        }
-      }
     }
   }
 
@@ -4177,30 +4108,6 @@ public final class DSL extends BaseDSL {
           });
         } else {
           ((AutoCompleteTextView) v).setOnItemClickListener((AdapterView.OnItemClickListener) null);
-        }
-      }
-      if (v instanceof ExpandableListView) {
-        if (arg != null) {
-          ((ExpandableListView) v).setOnItemClickListener(new AdapterView.OnItemClickListener() {
-            public void onItemClick(AdapterView a0, View a1, int a2, long a3) {
-              arg.onItemClick(a0, a1, a2, a3);
-              Anvil.render();
-            }
-          });
-        } else {
-          ((ExpandableListView) v).setOnItemClickListener((AdapterView.OnItemClickListener) null);
-        }
-      }
-      if (v instanceof Spinner) {
-        if (arg != null) {
-          ((Spinner) v).setOnItemClickListener(new AdapterView.OnItemClickListener() {
-            public void onItemClick(AdapterView a0, View a1, int a2, long a3) {
-              arg.onItemClick(a0, a1, a2, a3);
-              Anvil.render();
-            }
-          });
-        } else {
-          ((Spinner) v).setOnItemClickListener((AdapterView.OnItemClickListener) null);
         }
       }
     }
@@ -4885,20 +4792,11 @@ public final class DSL extends BaseDSL {
     public static final SelectionFunc8567756a instance = new SelectionFunc8567756a();
 
     public void apply(View v, final Integer arg, final Integer old) {
-      if (v instanceof AbsSpinner) {
-        ((AbsSpinner) v).setSelection(arg);
-      }
       if (v instanceof AdapterView) {
         ((AdapterView) v).setSelection(arg);
       }
       if (v instanceof EditText) {
         ((EditText) v).setSelection(arg);
-      }
-      if (v instanceof GridView) {
-        ((GridView) v).setSelection(arg);
-      }
-      if (v instanceof ListView) {
-        ((ListView) v).setSelection(arg);
       }
     }
   }

--- a/anvil/src/sdk15/java/trikita/anvil/DSL.java
+++ b/anvil/src/sdk15/java/trikita/anvil/DSL.java
@@ -1849,10 +1849,6 @@ public final class DSL extends BaseDSL {
     return BaseDSL.attr(PersistentDrawingCacheFunc8567756a.instance, arg);
   }
 
-  public static Void pictureListener(WebView.PictureListener arg) {
-    return BaseDSL.attr(PictureListenerFunc42b89430.instance, arg);
-  }
-
   public static Void pivotX(float arg) {
     return BaseDSL.attr(PivotXFunce0893188.instance, arg);
   }
@@ -2366,12 +2362,6 @@ public final class DSL extends BaseDSL {
       if (v instanceof AdapterView) {
         ((AdapterView) v).setAdapter(arg);
       }
-      if (v instanceof AdapterViewAnimator) {
-        ((AdapterViewAnimator) v).setAdapter(arg);
-      }
-      if (v instanceof AdapterViewFlipper) {
-        ((AdapterViewFlipper) v).setAdapter(arg);
-      }
     }
   }
 
@@ -2636,9 +2626,6 @@ public final class DSL extends BaseDSL {
       if (v instanceof AbsListView) {
         ((AbsListView) v).setCacheColorHint(arg);
       }
-      if (v instanceof ListView) {
-        ((ListView) v).setCacheColorHint(arg);
-      }
     }
   }
 
@@ -2709,12 +2696,6 @@ public final class DSL extends BaseDSL {
       }
       if (v instanceof CompoundButton) {
         ((CompoundButton) v).setChecked(arg);
-      }
-      if (v instanceof Switch) {
-        ((Switch) v).setChecked(arg);
-      }
-      if (v instanceof ToggleButton) {
-        ((ToggleButton) v).setChecked(arg);
       }
     }
   }
@@ -3008,9 +2989,6 @@ public final class DSL extends BaseDSL {
       if (v instanceof LinearLayout) {
         ((LinearLayout) v).setDividerDrawable(arg);
       }
-      if (v instanceof TabWidget) {
-        ((TabWidget) v).setDividerDrawable(arg);
-      }
     }
   }
 
@@ -3230,9 +3208,6 @@ public final class DSL extends BaseDSL {
     public static final EllipsizeFunc63cb4885 instance = new EllipsizeFunc63cb4885();
 
     public void apply(View v, final TextUtils.TruncateAt arg, final TextUtils.TruncateAt old) {
-      if (v instanceof EditText) {
-        ((EditText) v).setEllipsize(arg);
-      }
       if (v instanceof TextView) {
         ((TextView) v).setEllipsize(arg);
       }
@@ -3301,9 +3276,6 @@ public final class DSL extends BaseDSL {
     public static final ExtractedTextFunc410b6fe0 instance = new ExtractedTextFunc410b6fe0();
 
     public void apply(View v, final ExtractedText arg, final ExtractedText old) {
-      if (v instanceof ExtractEditText) {
-        ((ExtractEditText) v).setExtractedText(arg);
-      }
       if (v instanceof TextView) {
         ((TextView) v).setExtractedText(arg);
       }
@@ -4290,14 +4262,8 @@ public final class DSL extends BaseDSL {
     public static final MaxFunc8567756a instance = new MaxFunc8567756a();
 
     public void apply(View v, final Integer arg, final Integer old) {
-      if (v instanceof AbsSeekBar) {
-        ((AbsSeekBar) v).setMax(arg);
-      }
       if (v instanceof ProgressBar) {
         ((ProgressBar) v).setMax(arg);
-      }
-      if (v instanceof RatingBar) {
-        ((RatingBar) v).setMax(arg);
       }
     }
   }
@@ -4630,7 +4596,7 @@ public final class DSL extends BaseDSL {
             }
           });
         } else {
-          ((FragmentBreadCrumbs) v).setOnBreadCrumbClickListener(null);
+          ((FragmentBreadCrumbs) v).setOnBreadCrumbClickListener((FragmentBreadCrumbs.OnBreadCrumbClickListener) null);
         }
       }
     }
@@ -4649,7 +4615,7 @@ public final class DSL extends BaseDSL {
             }
           });
         } else {
-          ((CompoundButton) v).setOnCheckedChangeListener(null);
+          ((CompoundButton) v).setOnCheckedChangeListener((CompoundButton.OnCheckedChangeListener) null);
         }
       }
     }
@@ -4668,7 +4634,7 @@ public final class DSL extends BaseDSL {
             }
           });
         } else {
-          ((RadioGroup) v).setOnCheckedChangeListener(null);
+          ((RadioGroup) v).setOnCheckedChangeListener((RadioGroup.OnCheckedChangeListener) null);
         }
       }
     }
@@ -4688,7 +4654,7 @@ public final class DSL extends BaseDSL {
             }
           });
         } else {
-          ((ExpandableListView) v).setOnChildClickListener(null);
+          ((ExpandableListView) v).setOnChildClickListener((ExpandableListView.OnChildClickListener) null);
         }
       }
     }
@@ -4707,7 +4673,7 @@ public final class DSL extends BaseDSL {
             }
           });
         } else {
-          ((Chronometer) v).setOnChronometerTickListener(null);
+          ((Chronometer) v).setOnChronometerTickListener((Chronometer.OnChronometerTickListener) null);
         }
       }
     }
@@ -4725,7 +4691,7 @@ public final class DSL extends BaseDSL {
           }
         });
       } else {
-        v.setOnClickListener(null);
+        v.setOnClickListener((View.OnClickListener) null);
       }
     }
   }
@@ -4744,7 +4710,7 @@ public final class DSL extends BaseDSL {
             }
           });
         } else {
-          ((SearchView) v).setOnCloseListener(null);
+          ((SearchView) v).setOnCloseListener((SearchView.OnCloseListener) null);
         }
       }
     }
@@ -4763,7 +4729,7 @@ public final class DSL extends BaseDSL {
             }
           });
         } else {
-          ((VideoView) v).setOnCompletionListener(null);
+          ((VideoView) v).setOnCompletionListener((MediaPlayer.OnCompletionListener) null);
         }
       }
     }
@@ -4781,7 +4747,7 @@ public final class DSL extends BaseDSL {
           }
         });
       } else {
-        v.setOnCreateContextMenuListener(null);
+        v.setOnCreateContextMenuListener((View.OnCreateContextMenuListener) null);
       }
     }
   }
@@ -4799,7 +4765,7 @@ public final class DSL extends BaseDSL {
             }
           });
         } else {
-          ((CalendarView) v).setOnDateChangeListener(null);
+          ((CalendarView) v).setOnDateChangeListener((CalendarView.OnDateChangeListener) null);
         }
       }
     }
@@ -4818,7 +4784,7 @@ public final class DSL extends BaseDSL {
           }
         });
       } else {
-        v.setOnDragListener(null);
+        v.setOnDragListener((View.OnDragListener) null);
       }
     }
   }
@@ -4836,7 +4802,7 @@ public final class DSL extends BaseDSL {
             }
           });
         } else {
-          ((SlidingDrawer) v).setOnDrawerCloseListener(null);
+          ((SlidingDrawer) v).setOnDrawerCloseListener((SlidingDrawer.OnDrawerCloseListener) null);
         }
       }
     }
@@ -4855,7 +4821,7 @@ public final class DSL extends BaseDSL {
             }
           });
         } else {
-          ((SlidingDrawer) v).setOnDrawerOpenListener(null);
+          ((SlidingDrawer) v).setOnDrawerOpenListener((SlidingDrawer.OnDrawerOpenListener) null);
         }
       }
     }
@@ -4879,7 +4845,7 @@ public final class DSL extends BaseDSL {
             }
           });
         } else {
-          ((SlidingDrawer) v).setOnDrawerScrollListener(null);
+          ((SlidingDrawer) v).setOnDrawerScrollListener((SlidingDrawer.OnDrawerScrollListener) null);
         }
       }
     }
@@ -4899,7 +4865,7 @@ public final class DSL extends BaseDSL {
             }
           });
         } else {
-          ((TextView) v).setOnEditorActionListener(null);
+          ((TextView) v).setOnEditorActionListener((TextView.OnEditorActionListener) null);
         }
       }
     }
@@ -4919,7 +4885,7 @@ public final class DSL extends BaseDSL {
             }
           });
         } else {
-          ((VideoView) v).setOnErrorListener(null);
+          ((VideoView) v).setOnErrorListener((MediaPlayer.OnErrorListener) null);
         }
       }
     }
@@ -4937,7 +4903,7 @@ public final class DSL extends BaseDSL {
           }
         });
       } else {
-        v.setOnFocusChangeListener(null);
+        v.setOnFocusChangeListener((View.OnFocusChangeListener) null);
       }
     }
   }
@@ -4955,7 +4921,7 @@ public final class DSL extends BaseDSL {
           }
         });
       } else {
-        v.setOnGenericMotionListener(null);
+        v.setOnGenericMotionListener((View.OnGenericMotionListener) null);
       }
     }
   }
@@ -4974,7 +4940,7 @@ public final class DSL extends BaseDSL {
             }
           });
         } else {
-          ((ExpandableListView) v).setOnGroupClickListener(null);
+          ((ExpandableListView) v).setOnGroupClickListener((ExpandableListView.OnGroupClickListener) null);
         }
       }
     }
@@ -4993,7 +4959,7 @@ public final class DSL extends BaseDSL {
             }
           });
         } else {
-          ((ExpandableListView) v).setOnGroupCollapseListener(null);
+          ((ExpandableListView) v).setOnGroupCollapseListener((ExpandableListView.OnGroupCollapseListener) null);
         }
       }
     }
@@ -5012,7 +4978,7 @@ public final class DSL extends BaseDSL {
             }
           });
         } else {
-          ((ExpandableListView) v).setOnGroupExpandListener(null);
+          ((ExpandableListView) v).setOnGroupExpandListener((ExpandableListView.OnGroupExpandListener) null);
         }
       }
     }
@@ -5036,58 +5002,7 @@ public final class DSL extends BaseDSL {
             }
           });
         } else {
-          ((ViewGroup) v).setOnHierarchyChangeListener(null);
-        }
-      }
-      if (v instanceof RadioGroup) {
-        if (arg != null) {
-          ((RadioGroup) v).setOnHierarchyChangeListener(new ViewGroup.OnHierarchyChangeListener() {
-            public void onChildViewAdded(View a0, View a1) {
-              arg.onChildViewAdded(a0, a1);
-              Anvil.render();
-            }
-
-            public void onChildViewRemoved(View a0, View a1) {
-              arg.onChildViewRemoved(a0, a1);
-              Anvil.render();
-            }
-          });
-        } else {
-          ((RadioGroup) v).setOnHierarchyChangeListener(null);
-        }
-      }
-      if (v instanceof TableLayout) {
-        if (arg != null) {
-          ((TableLayout) v).setOnHierarchyChangeListener(new ViewGroup.OnHierarchyChangeListener() {
-            public void onChildViewAdded(View a0, View a1) {
-              arg.onChildViewAdded(a0, a1);
-              Anvil.render();
-            }
-
-            public void onChildViewRemoved(View a0, View a1) {
-              arg.onChildViewRemoved(a0, a1);
-              Anvil.render();
-            }
-          });
-        } else {
-          ((TableLayout) v).setOnHierarchyChangeListener(null);
-        }
-      }
-      if (v instanceof TableRow) {
-        if (arg != null) {
-          ((TableRow) v).setOnHierarchyChangeListener(new ViewGroup.OnHierarchyChangeListener() {
-            public void onChildViewAdded(View a0, View a1) {
-              arg.onChildViewAdded(a0, a1);
-              Anvil.render();
-            }
-
-            public void onChildViewRemoved(View a0, View a1) {
-              arg.onChildViewRemoved(a0, a1);
-              Anvil.render();
-            }
-          });
-        } else {
-          ((TableRow) v).setOnHierarchyChangeListener(null);
+          ((ViewGroup) v).setOnHierarchyChangeListener((ViewGroup.OnHierarchyChangeListener) null);
         }
       }
     }
@@ -5106,7 +5021,7 @@ public final class DSL extends BaseDSL {
           }
         });
       } else {
-        v.setOnHoverListener(null);
+        v.setOnHoverListener((View.OnHoverListener) null);
       }
     }
   }
@@ -5124,7 +5039,7 @@ public final class DSL extends BaseDSL {
             }
           });
         } else {
-          ((ViewStub) v).setOnInflateListener(null);
+          ((ViewStub) v).setOnInflateListener((ViewStub.OnInflateListener) null);
         }
       }
     }
@@ -5143,7 +5058,7 @@ public final class DSL extends BaseDSL {
             }
           });
         } else {
-          ((AdapterView) v).setOnItemClickListener(null);
+          ((AdapterView) v).setOnItemClickListener((AdapterView.OnItemClickListener) null);
         }
       }
       if (v instanceof AutoCompleteTextView) {
@@ -5155,31 +5070,7 @@ public final class DSL extends BaseDSL {
             }
           });
         } else {
-          ((AutoCompleteTextView) v).setOnItemClickListener(null);
-        }
-      }
-      if (v instanceof ExpandableListView) {
-        if (arg != null) {
-          ((ExpandableListView) v).setOnItemClickListener(new AdapterView.OnItemClickListener() {
-            public void onItemClick(AdapterView a0, View a1, int a2, long a3) {
-              arg.onItemClick(a0, a1, a2, a3);
-              Anvil.render();
-            }
-          });
-        } else {
-          ((ExpandableListView) v).setOnItemClickListener(null);
-        }
-      }
-      if (v instanceof Spinner) {
-        if (arg != null) {
-          ((Spinner) v).setOnItemClickListener(new AdapterView.OnItemClickListener() {
-            public void onItemClick(AdapterView a0, View a1, int a2, long a3) {
-              arg.onItemClick(a0, a1, a2, a3);
-              Anvil.render();
-            }
-          });
-        } else {
-          ((Spinner) v).setOnItemClickListener(null);
+          ((AutoCompleteTextView) v).setOnItemClickListener((AdapterView.OnItemClickListener) null);
         }
       }
     }
@@ -5199,7 +5090,7 @@ public final class DSL extends BaseDSL {
             }
           });
         } else {
-          ((AdapterView) v).setOnItemLongClickListener(null);
+          ((AdapterView) v).setOnItemLongClickListener((AdapterView.OnItemLongClickListener) null);
         }
       }
     }
@@ -5223,7 +5114,7 @@ public final class DSL extends BaseDSL {
             }
           });
         } else {
-          ((AdapterView) v).setOnItemSelectedListener(null);
+          ((AdapterView) v).setOnItemSelectedListener((AdapterView.OnItemSelectedListener) null);
         }
       }
       if (v instanceof AutoCompleteTextView) {
@@ -5240,7 +5131,7 @@ public final class DSL extends BaseDSL {
             }
           });
         } else {
-          ((AutoCompleteTextView) v).setOnItemSelectedListener(null);
+          ((AutoCompleteTextView) v).setOnItemSelectedListener((AdapterView.OnItemSelectedListener) null);
         }
       }
     }
@@ -5259,7 +5150,7 @@ public final class DSL extends BaseDSL {
           }
         });
       } else {
-        v.setOnKeyListener(null);
+        v.setOnKeyListener((View.OnKeyListener) null);
       }
     }
   }
@@ -5312,7 +5203,7 @@ public final class DSL extends BaseDSL {
             }
           });
         } else {
-          ((KeyboardView) v).setOnKeyboardActionListener(null);
+          ((KeyboardView) v).setOnKeyboardActionListener((KeyboardView.OnKeyboardActionListener) null);
         }
       }
     }
@@ -5331,7 +5222,7 @@ public final class DSL extends BaseDSL {
           }
         });
       } else {
-        v.setOnLongClickListener(null);
+        v.setOnLongClickListener((View.OnLongClickListener) null);
       }
     }
   }
@@ -5359,7 +5250,7 @@ public final class DSL extends BaseDSL {
             }
           });
         } else {
-          ((VideoView) v).setOnPreparedListener(null);
+          ((VideoView) v).setOnPreparedListener((MediaPlayer.OnPreparedListener) null);
         }
       }
     }
@@ -5385,7 +5276,7 @@ public final class DSL extends BaseDSL {
             }
           });
         } else {
-          ((SearchView) v).setOnQueryTextListener(null);
+          ((SearchView) v).setOnQueryTextListener((SearchView.OnQueryTextListener) null);
         }
       }
     }
@@ -5404,7 +5295,7 @@ public final class DSL extends BaseDSL {
             }
           });
         } else {
-          ((SearchView) v).setOnQueryTextFocusChangeListener(null);
+          ((SearchView) v).setOnQueryTextFocusChangeListener((View.OnFocusChangeListener) null);
         }
       }
     }
@@ -5423,7 +5314,7 @@ public final class DSL extends BaseDSL {
             }
           });
         } else {
-          ((RatingBar) v).setOnRatingBarChangeListener(null);
+          ((RatingBar) v).setOnRatingBarChangeListener((RatingBar.OnRatingBarChangeListener) null);
         }
       }
     }
@@ -5447,7 +5338,7 @@ public final class DSL extends BaseDSL {
             }
           });
         } else {
-          ((AbsListView) v).setOnScrollListener(null);
+          ((AbsListView) v).setOnScrollListener((AbsListView.OnScrollListener) null);
         }
       }
     }
@@ -5466,7 +5357,7 @@ public final class DSL extends BaseDSL {
             }
           });
         } else {
-          ((NumberPicker) v).setOnScrollListener(null);
+          ((NumberPicker) v).setOnScrollListener((NumberPicker.OnScrollListener) null);
         }
       }
     }
@@ -5485,7 +5376,7 @@ public final class DSL extends BaseDSL {
             }
           });
         } else {
-          ((SearchView) v).setOnSearchClickListener(null);
+          ((SearchView) v).setOnSearchClickListener((View.OnClickListener) null);
         }
       }
     }
@@ -5514,7 +5405,7 @@ public final class DSL extends BaseDSL {
             }
           });
         } else {
-          ((SeekBar) v).setOnSeekBarChangeListener(null);
+          ((SeekBar) v).setOnSeekBarChangeListener((SeekBar.OnSeekBarChangeListener) null);
         }
       }
     }
@@ -5540,7 +5431,7 @@ public final class DSL extends BaseDSL {
             }
           });
         } else {
-          ((SearchView) v).setOnSuggestionListener(null);
+          ((SearchView) v).setOnSuggestionListener((SearchView.OnSuggestionListener) null);
         }
       }
     }
@@ -5558,7 +5449,7 @@ public final class DSL extends BaseDSL {
           }
         });
       } else {
-        v.setOnSystemUiVisibilityChangeListener(null);
+        v.setOnSystemUiVisibilityChangeListener((View.OnSystemUiVisibilityChangeListener) null);
       }
     }
   }
@@ -5576,7 +5467,7 @@ public final class DSL extends BaseDSL {
             }
           });
         } else {
-          ((TabHost) v).setOnTabChangedListener(null);
+          ((TabHost) v).setOnTabChangedListener((TabHost.OnTabChangeListener) null);
         }
       }
     }
@@ -5595,7 +5486,7 @@ public final class DSL extends BaseDSL {
             }
           });
         } else {
-          ((TimePicker) v).setOnTimeChangedListener(null);
+          ((TimePicker) v).setOnTimeChangedListener((TimePicker.OnTimeChangedListener) null);
         }
       }
     }
@@ -5614,7 +5505,7 @@ public final class DSL extends BaseDSL {
           }
         });
       } else {
-        v.setOnTouchListener(null);
+        v.setOnTouchListener((View.OnTouchListener) null);
       }
     }
   }
@@ -5632,7 +5523,7 @@ public final class DSL extends BaseDSL {
             }
           });
         } else {
-          ((NumberPicker) v).setOnValueChangedListener(null);
+          ((NumberPicker) v).setOnValueChangedListener((NumberPicker.OnValueChangeListener) null);
         }
       }
     }
@@ -5651,7 +5542,7 @@ public final class DSL extends BaseDSL {
             }
           });
         } else {
-          ((ZoomControls) v).setOnZoomInClickListener(null);
+          ((ZoomControls) v).setOnZoomInClickListener((View.OnClickListener) null);
         }
       }
     }
@@ -5670,7 +5561,7 @@ public final class DSL extends BaseDSL {
             }
           });
         } else {
-          ((ZoomControls) v).setOnZoomOutClickListener(null);
+          ((ZoomControls) v).setOnZoomOutClickListener((View.OnClickListener) null);
         }
       }
     }
@@ -5766,16 +5657,6 @@ public final class DSL extends BaseDSL {
     public void apply(View v, final Integer arg, final Integer old) {
       if (v instanceof ViewGroup) {
         ((ViewGroup) v).setPersistentDrawingCache(arg);
-      }
-    }
-  }
-
-  private static final class PictureListenerFunc42b89430 implements Anvil.AttrFunc<WebView.PictureListener> {
-    public static final PictureListenerFunc42b89430 instance = new PictureListenerFunc42b89430();
-
-    public void apply(View v, final WebView.PictureListener arg, final WebView.PictureListener old) {
-      if (v instanceof WebView) {
-        ((WebView) v).setPictureListener(arg);
       }
     }
   }
@@ -5953,12 +5834,6 @@ public final class DSL extends BaseDSL {
       }
       if (v instanceof AdapterViewAnimator) {
         ((AdapterViewAnimator) v).setRemoteViewsAdapter(arg);
-      }
-      if (v instanceof GridView) {
-        ((GridView) v).setRemoteViewsAdapter(arg);
-      }
-      if (v instanceof ListView) {
-        ((ListView) v).setRemoteViewsAdapter(arg);
       }
     }
   }
@@ -6209,23 +6084,11 @@ public final class DSL extends BaseDSL {
     public static final SelectionFunc8567756a instance = new SelectionFunc8567756a();
 
     public void apply(View v, final Integer arg, final Integer old) {
-      if (v instanceof AbsSpinner) {
-        ((AbsSpinner) v).setSelection(arg);
-      }
       if (v instanceof AdapterView) {
         ((AdapterView) v).setSelection(arg);
       }
-      if (v instanceof AdapterViewAnimator) {
-        ((AdapterViewAnimator) v).setSelection(arg);
-      }
       if (v instanceof EditText) {
         ((EditText) v).setSelection(arg);
-      }
-      if (v instanceof GridView) {
-        ((GridView) v).setSelection(arg);
-      }
-      if (v instanceof ListView) {
-        ((ListView) v).setSelection(arg);
       }
     }
   }

--- a/anvil/src/sdk19/java/trikita/anvil/DSL.java
+++ b/anvil/src/sdk19/java/trikita/anvil/DSL.java
@@ -26,7 +26,6 @@ import android.inputmethodservice.Keyboard;
 import android.inputmethodservice.KeyboardView;
 import android.media.MediaPlayer;
 import android.net.Uri;
-import android.net.http.SslCertificate;
 import android.opengl.GLSurfaceView;
 import android.text.Editable;
 import android.text.InputFilter;
@@ -792,10 +791,6 @@ public final class DSL extends BaseDSL {
     return BaseDSL.attr(AlphaFunce0893188.instance, arg);
   }
 
-  public static Void alpha(int arg) {
-    return BaseDSL.attr(AlphaFunc8567756a.instance, arg);
-  }
-
   public static Void alwaysDrawnWithCacheEnabled(boolean arg) {
     return BaseDSL.attr(AlwaysDrawnWithCacheEnabledFunc148d6054.instance, arg);
   }
@@ -834,10 +829,6 @@ public final class DSL extends BaseDSL {
 
   public static Void backgroundColor(int arg) {
     return BaseDSL.attr(BackgroundColorFunc8567756a.instance, arg);
-  }
-
-  public static Void backgroundDrawable(Drawable arg) {
-    return BaseDSL.attr(BackgroundDrawableFuncfb47464a.instance, arg);
   }
 
   public static Void backgroundResource(int arg) {
@@ -890,10 +881,6 @@ public final class DSL extends BaseDSL {
 
   public static Void cameraDistance(float arg) {
     return BaseDSL.attr(CameraDistanceFunce0893188.instance, arg);
-  }
-
-  public static Void certificate(SslCertificate arg) {
-    return BaseDSL.attr(CertificateFuncde9d69e1.instance, arg);
   }
 
   public static Void checkMarkDrawable(Drawable arg) {
@@ -1584,10 +1571,6 @@ public final class DSL extends BaseDSL {
     return BaseDSL.attr(LongClickableFunc148d6054.instance, arg);
   }
 
-  public static Void mapTrackballToArrowKeys(boolean arg) {
-    return BaseDSL.attr(MapTrackballToArrowKeysFunc148d6054.instance, arg);
-  }
-
   public static Void marqueeRepeatLimit(int arg) {
     return BaseDSL.attr(MarqueeRepeatLimitFunc8567756a.instance, arg);
   }
@@ -1950,10 +1933,6 @@ public final class DSL extends BaseDSL {
 
   public static Void persistentDrawingCache(int arg) {
     return BaseDSL.attr(PersistentDrawingCacheFunc8567756a.instance, arg);
-  }
-
-  public static Void pictureListener(WebView.PictureListener arg) {
-    return BaseDSL.attr(PictureListenerFunc42b89430.instance, arg);
   }
 
   public static Void pivotX(float arg) {
@@ -2589,12 +2568,6 @@ public final class DSL extends BaseDSL {
       if (v instanceof AdapterView) {
         ((AdapterView) v).setAdapter(arg);
       }
-      if (v instanceof AdapterViewAnimator) {
-        ((AdapterViewAnimator) v).setAdapter(arg);
-      }
-      if (v instanceof AdapterViewFlipper) {
-        ((AdapterViewFlipper) v).setAdapter(arg);
-      }
     }
   }
 
@@ -2653,16 +2626,6 @@ public final class DSL extends BaseDSL {
 
     public void apply(View v, final Float arg, final Float old) {
       v.setAlpha(arg);
-    }
-  }
-
-  private static final class AlphaFunc8567756a implements Anvil.AttrFunc<Integer> {
-    public static final AlphaFunc8567756a instance = new AlphaFunc8567756a();
-
-    public void apply(View v, final Integer arg, final Integer old) {
-      if (v instanceof ImageView) {
-        ((ImageView) v).setAlpha(arg);
-      }
     }
   }
 
@@ -2766,14 +2729,6 @@ public final class DSL extends BaseDSL {
     }
   }
 
-  private static final class BackgroundDrawableFuncfb47464a implements Anvil.AttrFunc<Drawable> {
-    public static final BackgroundDrawableFuncfb47464a instance = new BackgroundDrawableFuncfb47464a();
-
-    public void apply(View v, final Drawable arg, final Drawable old) {
-      v.setBackgroundDrawable(arg);
-    }
-  }
-
   private static final class BackgroundResourceFunc8567756a implements Anvil.AttrFunc<Integer> {
     public static final BackgroundResourceFunc8567756a instance = new BackgroundResourceFunc8567756a();
 
@@ -2867,9 +2822,6 @@ public final class DSL extends BaseDSL {
       if (v instanceof AbsListView) {
         ((AbsListView) v).setCacheColorHint(arg);
       }
-      if (v instanceof ListView) {
-        ((ListView) v).setCacheColorHint(arg);
-      }
     }
   }
 
@@ -2898,16 +2850,6 @@ public final class DSL extends BaseDSL {
 
     public void apply(View v, final Float arg, final Float old) {
       v.setCameraDistance(arg);
-    }
-  }
-
-  private static final class CertificateFuncde9d69e1 implements Anvil.AttrFunc<SslCertificate> {
-    public static final CertificateFuncde9d69e1 instance = new CertificateFuncde9d69e1();
-
-    public void apply(View v, final SslCertificate arg, final SslCertificate old) {
-      if (v instanceof WebView) {
-        ((WebView) v).setCertificate(arg);
-      }
     }
   }
 
@@ -2940,12 +2882,6 @@ public final class DSL extends BaseDSL {
       }
       if (v instanceof CompoundButton) {
         ((CompoundButton) v).setChecked(arg);
-      }
-      if (v instanceof Switch) {
-        ((Switch) v).setChecked(arg);
-      }
-      if (v instanceof ToggleButton) {
-        ((ToggleButton) v).setChecked(arg);
       }
     }
   }
@@ -3267,9 +3203,6 @@ public final class DSL extends BaseDSL {
       if (v instanceof LinearLayout) {
         ((LinearLayout) v).setDividerDrawable(arg);
       }
-      if (v instanceof TabWidget) {
-        ((TabWidget) v).setDividerDrawable(arg);
-      }
     }
   }
 
@@ -3498,9 +3431,6 @@ public final class DSL extends BaseDSL {
     public static final EllipsizeFunc63cb4885 instance = new EllipsizeFunc63cb4885();
 
     public void apply(View v, final TextUtils.TruncateAt arg, final TextUtils.TruncateAt old) {
-      if (v instanceof EditText) {
-        ((EditText) v).setEllipsize(arg);
-      }
       if (v instanceof TextView) {
         ((TextView) v).setEllipsize(arg);
       }
@@ -3579,9 +3509,6 @@ public final class DSL extends BaseDSL {
     public static final ExtractedTextFunc410b6fe0 instance = new ExtractedTextFunc410b6fe0();
 
     public void apply(View v, final ExtractedText arg, final ExtractedText old) {
-      if (v instanceof ExtractEditText) {
-        ((ExtractEditText) v).setExtractedText(arg);
-      }
       if (v instanceof TextView) {
         ((TextView) v).setExtractedText(arg);
       }
@@ -4654,16 +4581,6 @@ public final class DSL extends BaseDSL {
     }
   }
 
-  private static final class MapTrackballToArrowKeysFunc148d6054 implements Anvil.AttrFunc<Boolean> {
-    public static final MapTrackballToArrowKeysFunc148d6054 instance = new MapTrackballToArrowKeysFunc148d6054();
-
-    public void apply(View v, final Boolean arg, final Boolean old) {
-      if (v instanceof WebView) {
-        ((WebView) v).setMapTrackballToArrowKeys(arg);
-      }
-    }
-  }
-
   private static final class MarqueeRepeatLimitFunc8567756a implements Anvil.AttrFunc<Integer> {
     public static final MarqueeRepeatLimitFunc8567756a instance = new MarqueeRepeatLimitFunc8567756a();
 
@@ -4678,14 +4595,8 @@ public final class DSL extends BaseDSL {
     public static final MaxFunc8567756a instance = new MaxFunc8567756a();
 
     public void apply(View v, final Integer arg, final Integer old) {
-      if (v instanceof AbsSeekBar) {
-        ((AbsSeekBar) v).setMax(arg);
-      }
       if (v instanceof ProgressBar) {
         ((ProgressBar) v).setMax(arg);
-      }
-      if (v instanceof RatingBar) {
-        ((RatingBar) v).setMax(arg);
       }
     }
   }
@@ -5018,7 +4929,7 @@ public final class DSL extends BaseDSL {
             }
           });
         } else {
-          ((FragmentBreadCrumbs) v).setOnBreadCrumbClickListener(null);
+          ((FragmentBreadCrumbs) v).setOnBreadCrumbClickListener((FragmentBreadCrumbs.OnBreadCrumbClickListener) null);
         }
       }
     }
@@ -5037,7 +4948,7 @@ public final class DSL extends BaseDSL {
             }
           });
         } else {
-          ((CompoundButton) v).setOnCheckedChangeListener(null);
+          ((CompoundButton) v).setOnCheckedChangeListener((CompoundButton.OnCheckedChangeListener) null);
         }
       }
     }
@@ -5056,7 +4967,7 @@ public final class DSL extends BaseDSL {
             }
           });
         } else {
-          ((RadioGroup) v).setOnCheckedChangeListener(null);
+          ((RadioGroup) v).setOnCheckedChangeListener((RadioGroup.OnCheckedChangeListener) null);
         }
       }
     }
@@ -5076,7 +4987,7 @@ public final class DSL extends BaseDSL {
             }
           });
         } else {
-          ((ExpandableListView) v).setOnChildClickListener(null);
+          ((ExpandableListView) v).setOnChildClickListener((ExpandableListView.OnChildClickListener) null);
         }
       }
     }
@@ -5095,7 +5006,7 @@ public final class DSL extends BaseDSL {
             }
           });
         } else {
-          ((Chronometer) v).setOnChronometerTickListener(null);
+          ((Chronometer) v).setOnChronometerTickListener((Chronometer.OnChronometerTickListener) null);
         }
       }
     }
@@ -5113,7 +5024,7 @@ public final class DSL extends BaseDSL {
           }
         });
       } else {
-        v.setOnClickListener(null);
+        v.setOnClickListener((View.OnClickListener) null);
       }
     }
   }
@@ -5132,7 +5043,7 @@ public final class DSL extends BaseDSL {
             }
           });
         } else {
-          ((SearchView) v).setOnCloseListener(null);
+          ((SearchView) v).setOnCloseListener((SearchView.OnCloseListener) null);
         }
       }
     }
@@ -5151,7 +5062,7 @@ public final class DSL extends BaseDSL {
             }
           });
         } else {
-          ((VideoView) v).setOnCompletionListener(null);
+          ((VideoView) v).setOnCompletionListener((MediaPlayer.OnCompletionListener) null);
         }
       }
     }
@@ -5169,7 +5080,7 @@ public final class DSL extends BaseDSL {
           }
         });
       } else {
-        v.setOnCreateContextMenuListener(null);
+        v.setOnCreateContextMenuListener((View.OnCreateContextMenuListener) null);
       }
     }
   }
@@ -5187,7 +5098,7 @@ public final class DSL extends BaseDSL {
             }
           });
         } else {
-          ((CalendarView) v).setOnDateChangeListener(null);
+          ((CalendarView) v).setOnDateChangeListener((CalendarView.OnDateChangeListener) null);
         }
       }
     }
@@ -5206,7 +5117,7 @@ public final class DSL extends BaseDSL {
             }
           });
         } else {
-          ((AutoCompleteTextView) v).setOnDismissListener(null);
+          ((AutoCompleteTextView) v).setOnDismissListener((AutoCompleteTextView.OnDismissListener) null);
         }
       }
     }
@@ -5225,7 +5136,7 @@ public final class DSL extends BaseDSL {
           }
         });
       } else {
-        v.setOnDragListener(null);
+        v.setOnDragListener((View.OnDragListener) null);
       }
     }
   }
@@ -5243,7 +5154,7 @@ public final class DSL extends BaseDSL {
             }
           });
         } else {
-          ((SlidingDrawer) v).setOnDrawerCloseListener(null);
+          ((SlidingDrawer) v).setOnDrawerCloseListener((SlidingDrawer.OnDrawerCloseListener) null);
         }
       }
     }
@@ -5262,7 +5173,7 @@ public final class DSL extends BaseDSL {
             }
           });
         } else {
-          ((SlidingDrawer) v).setOnDrawerOpenListener(null);
+          ((SlidingDrawer) v).setOnDrawerOpenListener((SlidingDrawer.OnDrawerOpenListener) null);
         }
       }
     }
@@ -5286,7 +5197,7 @@ public final class DSL extends BaseDSL {
             }
           });
         } else {
-          ((SlidingDrawer) v).setOnDrawerScrollListener(null);
+          ((SlidingDrawer) v).setOnDrawerScrollListener((SlidingDrawer.OnDrawerScrollListener) null);
         }
       }
     }
@@ -5306,7 +5217,7 @@ public final class DSL extends BaseDSL {
             }
           });
         } else {
-          ((TextView) v).setOnEditorActionListener(null);
+          ((TextView) v).setOnEditorActionListener((TextView.OnEditorActionListener) null);
         }
       }
     }
@@ -5326,7 +5237,7 @@ public final class DSL extends BaseDSL {
             }
           });
         } else {
-          ((VideoView) v).setOnErrorListener(null);
+          ((VideoView) v).setOnErrorListener((MediaPlayer.OnErrorListener) null);
         }
       }
     }
@@ -5344,7 +5255,7 @@ public final class DSL extends BaseDSL {
           }
         });
       } else {
-        v.setOnFocusChangeListener(null);
+        v.setOnFocusChangeListener((View.OnFocusChangeListener) null);
       }
     }
   }
@@ -5362,7 +5273,7 @@ public final class DSL extends BaseDSL {
           }
         });
       } else {
-        v.setOnGenericMotionListener(null);
+        v.setOnGenericMotionListener((View.OnGenericMotionListener) null);
       }
     }
   }
@@ -5381,7 +5292,7 @@ public final class DSL extends BaseDSL {
             }
           });
         } else {
-          ((ExpandableListView) v).setOnGroupClickListener(null);
+          ((ExpandableListView) v).setOnGroupClickListener((ExpandableListView.OnGroupClickListener) null);
         }
       }
     }
@@ -5400,7 +5311,7 @@ public final class DSL extends BaseDSL {
             }
           });
         } else {
-          ((ExpandableListView) v).setOnGroupCollapseListener(null);
+          ((ExpandableListView) v).setOnGroupCollapseListener((ExpandableListView.OnGroupCollapseListener) null);
         }
       }
     }
@@ -5419,7 +5330,7 @@ public final class DSL extends BaseDSL {
             }
           });
         } else {
-          ((ExpandableListView) v).setOnGroupExpandListener(null);
+          ((ExpandableListView) v).setOnGroupExpandListener((ExpandableListView.OnGroupExpandListener) null);
         }
       }
     }
@@ -5443,58 +5354,7 @@ public final class DSL extends BaseDSL {
             }
           });
         } else {
-          ((ViewGroup) v).setOnHierarchyChangeListener(null);
-        }
-      }
-      if (v instanceof RadioGroup) {
-        if (arg != null) {
-          ((RadioGroup) v).setOnHierarchyChangeListener(new ViewGroup.OnHierarchyChangeListener() {
-            public void onChildViewAdded(View a0, View a1) {
-              arg.onChildViewAdded(a0, a1);
-              Anvil.render();
-            }
-
-            public void onChildViewRemoved(View a0, View a1) {
-              arg.onChildViewRemoved(a0, a1);
-              Anvil.render();
-            }
-          });
-        } else {
-          ((RadioGroup) v).setOnHierarchyChangeListener(null);
-        }
-      }
-      if (v instanceof TableLayout) {
-        if (arg != null) {
-          ((TableLayout) v).setOnHierarchyChangeListener(new ViewGroup.OnHierarchyChangeListener() {
-            public void onChildViewAdded(View a0, View a1) {
-              arg.onChildViewAdded(a0, a1);
-              Anvil.render();
-            }
-
-            public void onChildViewRemoved(View a0, View a1) {
-              arg.onChildViewRemoved(a0, a1);
-              Anvil.render();
-            }
-          });
-        } else {
-          ((TableLayout) v).setOnHierarchyChangeListener(null);
-        }
-      }
-      if (v instanceof TableRow) {
-        if (arg != null) {
-          ((TableRow) v).setOnHierarchyChangeListener(new ViewGroup.OnHierarchyChangeListener() {
-            public void onChildViewAdded(View a0, View a1) {
-              arg.onChildViewAdded(a0, a1);
-              Anvil.render();
-            }
-
-            public void onChildViewRemoved(View a0, View a1) {
-              arg.onChildViewRemoved(a0, a1);
-              Anvil.render();
-            }
-          });
-        } else {
-          ((TableRow) v).setOnHierarchyChangeListener(null);
+          ((ViewGroup) v).setOnHierarchyChangeListener((ViewGroup.OnHierarchyChangeListener) null);
         }
       }
     }
@@ -5513,7 +5373,7 @@ public final class DSL extends BaseDSL {
           }
         });
       } else {
-        v.setOnHoverListener(null);
+        v.setOnHoverListener((View.OnHoverListener) null);
       }
     }
   }
@@ -5531,7 +5391,7 @@ public final class DSL extends BaseDSL {
             }
           });
         } else {
-          ((ViewStub) v).setOnInflateListener(null);
+          ((ViewStub) v).setOnInflateListener((ViewStub.OnInflateListener) null);
         }
       }
     }
@@ -5551,7 +5411,7 @@ public final class DSL extends BaseDSL {
             }
           });
         } else {
-          ((VideoView) v).setOnInfoListener(null);
+          ((VideoView) v).setOnInfoListener((MediaPlayer.OnInfoListener) null);
         }
       }
     }
@@ -5570,7 +5430,7 @@ public final class DSL extends BaseDSL {
             }
           });
         } else {
-          ((AdapterView) v).setOnItemClickListener(null);
+          ((AdapterView) v).setOnItemClickListener((AdapterView.OnItemClickListener) null);
         }
       }
       if (v instanceof AutoCompleteTextView) {
@@ -5582,31 +5442,7 @@ public final class DSL extends BaseDSL {
             }
           });
         } else {
-          ((AutoCompleteTextView) v).setOnItemClickListener(null);
-        }
-      }
-      if (v instanceof ExpandableListView) {
-        if (arg != null) {
-          ((ExpandableListView) v).setOnItemClickListener(new AdapterView.OnItemClickListener() {
-            public void onItemClick(AdapterView a0, View a1, int a2, long a3) {
-              arg.onItemClick(a0, a1, a2, a3);
-              Anvil.render();
-            }
-          });
-        } else {
-          ((ExpandableListView) v).setOnItemClickListener(null);
-        }
-      }
-      if (v instanceof Spinner) {
-        if (arg != null) {
-          ((Spinner) v).setOnItemClickListener(new AdapterView.OnItemClickListener() {
-            public void onItemClick(AdapterView a0, View a1, int a2, long a3) {
-              arg.onItemClick(a0, a1, a2, a3);
-              Anvil.render();
-            }
-          });
-        } else {
-          ((Spinner) v).setOnItemClickListener(null);
+          ((AutoCompleteTextView) v).setOnItemClickListener((AdapterView.OnItemClickListener) null);
         }
       }
     }
@@ -5626,7 +5462,7 @@ public final class DSL extends BaseDSL {
             }
           });
         } else {
-          ((AdapterView) v).setOnItemLongClickListener(null);
+          ((AdapterView) v).setOnItemLongClickListener((AdapterView.OnItemLongClickListener) null);
         }
       }
     }
@@ -5650,7 +5486,7 @@ public final class DSL extends BaseDSL {
             }
           });
         } else {
-          ((AdapterView) v).setOnItemSelectedListener(null);
+          ((AdapterView) v).setOnItemSelectedListener((AdapterView.OnItemSelectedListener) null);
         }
       }
       if (v instanceof AutoCompleteTextView) {
@@ -5667,7 +5503,7 @@ public final class DSL extends BaseDSL {
             }
           });
         } else {
-          ((AutoCompleteTextView) v).setOnItemSelectedListener(null);
+          ((AutoCompleteTextView) v).setOnItemSelectedListener((AdapterView.OnItemSelectedListener) null);
         }
       }
     }
@@ -5686,7 +5522,7 @@ public final class DSL extends BaseDSL {
           }
         });
       } else {
-        v.setOnKeyListener(null);
+        v.setOnKeyListener((View.OnKeyListener) null);
       }
     }
   }
@@ -5739,7 +5575,7 @@ public final class DSL extends BaseDSL {
             }
           });
         } else {
-          ((KeyboardView) v).setOnKeyboardActionListener(null);
+          ((KeyboardView) v).setOnKeyboardActionListener((KeyboardView.OnKeyboardActionListener) null);
         }
       }
     }
@@ -5758,7 +5594,7 @@ public final class DSL extends BaseDSL {
           }
         });
       } else {
-        v.setOnLongClickListener(null);
+        v.setOnLongClickListener((View.OnLongClickListener) null);
       }
     }
   }
@@ -5786,7 +5622,7 @@ public final class DSL extends BaseDSL {
             }
           });
         } else {
-          ((VideoView) v).setOnPreparedListener(null);
+          ((VideoView) v).setOnPreparedListener((MediaPlayer.OnPreparedListener) null);
         }
       }
     }
@@ -5812,7 +5648,7 @@ public final class DSL extends BaseDSL {
             }
           });
         } else {
-          ((SearchView) v).setOnQueryTextListener(null);
+          ((SearchView) v).setOnQueryTextListener((SearchView.OnQueryTextListener) null);
         }
       }
     }
@@ -5831,7 +5667,7 @@ public final class DSL extends BaseDSL {
             }
           });
         } else {
-          ((SearchView) v).setOnQueryTextFocusChangeListener(null);
+          ((SearchView) v).setOnQueryTextFocusChangeListener((View.OnFocusChangeListener) null);
         }
       }
     }
@@ -5850,7 +5686,7 @@ public final class DSL extends BaseDSL {
             }
           });
         } else {
-          ((RatingBar) v).setOnRatingBarChangeListener(null);
+          ((RatingBar) v).setOnRatingBarChangeListener((RatingBar.OnRatingBarChangeListener) null);
         }
       }
     }
@@ -5874,7 +5710,7 @@ public final class DSL extends BaseDSL {
             }
           });
         } else {
-          ((AbsListView) v).setOnScrollListener(null);
+          ((AbsListView) v).setOnScrollListener((AbsListView.OnScrollListener) null);
         }
       }
     }
@@ -5893,7 +5729,7 @@ public final class DSL extends BaseDSL {
             }
           });
         } else {
-          ((NumberPicker) v).setOnScrollListener(null);
+          ((NumberPicker) v).setOnScrollListener((NumberPicker.OnScrollListener) null);
         }
       }
     }
@@ -5912,7 +5748,7 @@ public final class DSL extends BaseDSL {
             }
           });
         } else {
-          ((SearchView) v).setOnSearchClickListener(null);
+          ((SearchView) v).setOnSearchClickListener((View.OnClickListener) null);
         }
       }
     }
@@ -5941,7 +5777,7 @@ public final class DSL extends BaseDSL {
             }
           });
         } else {
-          ((SeekBar) v).setOnSeekBarChangeListener(null);
+          ((SeekBar) v).setOnSeekBarChangeListener((SeekBar.OnSeekBarChangeListener) null);
         }
       }
     }
@@ -5967,7 +5803,7 @@ public final class DSL extends BaseDSL {
             }
           });
         } else {
-          ((SearchView) v).setOnSuggestionListener(null);
+          ((SearchView) v).setOnSuggestionListener((SearchView.OnSuggestionListener) null);
         }
       }
     }
@@ -5985,7 +5821,7 @@ public final class DSL extends BaseDSL {
           }
         });
       } else {
-        v.setOnSystemUiVisibilityChangeListener(null);
+        v.setOnSystemUiVisibilityChangeListener((View.OnSystemUiVisibilityChangeListener) null);
       }
     }
   }
@@ -6003,7 +5839,7 @@ public final class DSL extends BaseDSL {
             }
           });
         } else {
-          ((TabHost) v).setOnTabChangedListener(null);
+          ((TabHost) v).setOnTabChangedListener((TabHost.OnTabChangeListener) null);
         }
       }
     }
@@ -6022,7 +5858,7 @@ public final class DSL extends BaseDSL {
             }
           });
         } else {
-          ((TimePicker) v).setOnTimeChangedListener(null);
+          ((TimePicker) v).setOnTimeChangedListener((TimePicker.OnTimeChangedListener) null);
         }
       }
     }
@@ -6041,7 +5877,7 @@ public final class DSL extends BaseDSL {
           }
         });
       } else {
-        v.setOnTouchListener(null);
+        v.setOnTouchListener((View.OnTouchListener) null);
       }
     }
   }
@@ -6059,7 +5895,7 @@ public final class DSL extends BaseDSL {
             }
           });
         } else {
-          ((NumberPicker) v).setOnValueChangedListener(null);
+          ((NumberPicker) v).setOnValueChangedListener((NumberPicker.OnValueChangeListener) null);
         }
       }
     }
@@ -6078,7 +5914,7 @@ public final class DSL extends BaseDSL {
             }
           });
         } else {
-          ((ZoomControls) v).setOnZoomInClickListener(null);
+          ((ZoomControls) v).setOnZoomInClickListener((View.OnClickListener) null);
         }
       }
     }
@@ -6097,7 +5933,7 @@ public final class DSL extends BaseDSL {
             }
           });
         } else {
-          ((ZoomControls) v).setOnZoomOutClickListener(null);
+          ((ZoomControls) v).setOnZoomOutClickListener((View.OnClickListener) null);
         }
       }
     }
@@ -6193,16 +6029,6 @@ public final class DSL extends BaseDSL {
     public void apply(View v, final Integer arg, final Integer old) {
       if (v instanceof ViewGroup) {
         ((ViewGroup) v).setPersistentDrawingCache(arg);
-      }
-    }
-  }
-
-  private static final class PictureListenerFunc42b89430 implements Anvil.AttrFunc<WebView.PictureListener> {
-    public static final PictureListenerFunc42b89430 instance = new PictureListenerFunc42b89430();
-
-    public void apply(View v, final WebView.PictureListener arg, final WebView.PictureListener old) {
-      if (v instanceof WebView) {
-        ((WebView) v).setPictureListener(arg);
       }
     }
   }
@@ -6400,12 +6226,6 @@ public final class DSL extends BaseDSL {
       }
       if (v instanceof AdapterViewAnimator) {
         ((AdapterViewAnimator) v).setRemoteViewsAdapter(arg);
-      }
-      if (v instanceof GridView) {
-        ((GridView) v).setRemoteViewsAdapter(arg);
-      }
-      if (v instanceof ListView) {
-        ((ListView) v).setRemoteViewsAdapter(arg);
       }
     }
   }
@@ -6730,23 +6550,11 @@ public final class DSL extends BaseDSL {
     public static final SelectionFunc8567756a instance = new SelectionFunc8567756a();
 
     public void apply(View v, final Integer arg, final Integer old) {
-      if (v instanceof AbsSpinner) {
-        ((AbsSpinner) v).setSelection(arg);
-      }
       if (v instanceof AdapterView) {
         ((AdapterView) v).setSelection(arg);
       }
-      if (v instanceof AdapterViewAnimator) {
-        ((AdapterViewAnimator) v).setSelection(arg);
-      }
       if (v instanceof EditText) {
         ((EditText) v).setSelection(arg);
-      }
-      if (v instanceof GridView) {
-        ((GridView) v).setSelection(arg);
-      }
-      if (v instanceof ListView) {
-        ((ListView) v).setSelection(arg);
       }
     }
   }


### PR DESCRIPTION
There are two types of duplicate methods which were being generated:
1. Deprecated methods which really shouldn't be around because they've
usually been replaced with a better name alternative.
2. Methods which are handled by superclasses and were being invkoed on
cast subclasses - these can be removed as they will be safely handled by
the super method.

Remove both of these types from being generated and shrink method count
quite a bit.