### PR TITLE
View factories

### DIFF
--- a/anvil/src/main/java/trikita/anvil/BaseDSL.java
+++ b/anvil/src/main/java/trikita/anvil/BaseDSL.java
@@ -716,6 +716,11 @@ public class BaseDSL {
 		return null;
 	}
 
+    public static ViewClassResult v(Anvil.FactoryFunc<? extends View> viewFactoryFunc) {
+        Anvil.currentMount().startFromFactory(viewFactoryFunc);
+        return null;
+    }
+
 	public static ViewClassResult xml(int layoutId) {
 		Anvil.currentMount().startFromLayout(layoutId);
 		return null;
@@ -734,6 +739,12 @@ public class BaseDSL {
 		r.view();
 		return end();
 	}
+
+    public static Void v(Anvil.FactoryFunc<? extends View> c, Anvil.Renderable r) {
+        v(c);
+        r.view();
+        return end();
+    }
 
 	public static Void xml(int layoutId, Anvil.Renderable r) {
 		xml(layoutId);

--- a/anvil/src/test/java/trikita/anvil/CurrentViewTest.java
+++ b/anvil/src/test/java/trikita/anvil/CurrentViewTest.java
@@ -33,4 +33,30 @@ public class CurrentViewTest extends Utils {
         });
         assertNull(Anvil.currentView());
     }
+
+    @Test
+    public void testCurrentViewWithFactoryFunc() {
+        assertNull(Anvil.currentView());
+        Anvil.mount(container, new Anvil.Renderable() {
+            public void view() {
+                assertTrue(Anvil.currentView() instanceof ViewGroup);
+                v(MockLayout.FACTORY, new Anvil.Renderable() {
+                    public void view() {
+                        assertTrue(Anvil.currentView() instanceof MockLayout);
+                        v(MockView.FACTORY, new Anvil.Renderable() {
+                            public void view() {
+                                assertTrue(Anvil.currentView() instanceof MockView);
+                                prop("foo", "bar");
+                                MockView view = Anvil.currentView(); // should cast automatically
+                                assertEquals("bar", view.props.get("foo"));
+                            }
+                        });
+                        assertTrue(Anvil.currentView() instanceof MockLayout);
+                    }
+                });
+                assertTrue(Anvil.currentView() instanceof ViewGroup);
+            }
+        });
+        assertNull(Anvil.currentView());
+    }
 }

--- a/anvil/src/test/java/trikita/anvil/IncrementalRenderTest.java
+++ b/anvil/src/test/java/trikita/anvil/IncrementalRenderTest.java
@@ -25,6 +25,20 @@ public class IncrementalRenderTest extends Utils {
     }
 
     @Test
+    public void testConstantsRenderedOnceWithFactoryFunc() {
+        Anvil.mount(container, new Anvil.Renderable() {
+            public void view() {
+                o(v(MockLayout.FACTORY), prop("foo", "bar"));
+            }
+        });
+        assertEquals(1, (int) createdViews.get(MockLayout.class));
+        assertEquals(1, (int) changedAttrs.get("foo"));
+        Anvil.render();
+        assertEquals(1, (int) createdViews.get(MockLayout.class));
+        assertEquals(1, (int) changedAttrs.get("foo"));
+    }
+
+    @Test
     public void testDynamicAttributeRenderedLazily() {
         Anvil.mount(container, new Anvil.Renderable() {
             public void view() {
@@ -49,6 +63,36 @@ public class IncrementalRenderTest extends Utils {
                         o(v(MockLayout.class)),
                         showView ?
                                 o(v(MockView.class)) :
+                                null);
+            }
+        });
+        MockLayout layout = (MockLayout) container.getChildAt(0);
+        assertEquals(2, layout.getChildCount());
+        assertEquals(1, (int) createdViews.get(MockView.class));
+        Anvil.render();
+        assertEquals(1, (int) createdViews.get(MockView.class));
+        showView = false;
+        Anvil.render();
+        assertEquals(1, layout.getChildCount());
+        assertEquals(1, (int) createdViews.get(MockView.class));
+        Anvil.render();
+        assertEquals(1, (int) createdViews.get(MockView.class));
+        showView = true;
+        Anvil.render();
+        assertEquals(2, layout.getChildCount());
+        assertEquals(2, (int) createdViews.get(MockView.class));
+        Anvil.render();
+        assertEquals(2, (int) createdViews.get(MockView.class));
+    }
+
+    @Test
+    public void testDynamicViewRenderedLazilyWithFactoryFunc() {
+        Anvil.mount(container, new Anvil.Renderable() {
+            public void view() {
+                o(v(MockLayout.FACTORY),
+                        o(v(MockLayout.FACTORY)),
+                        showView ?
+                                o(v(MockView.FACTORY)) :
                                 null);
             }
         });

--- a/anvil/src/test/java/trikita/anvil/Utils.java
+++ b/anvil/src/test/java/trikita/anvil/Utils.java
@@ -43,6 +43,14 @@ public class Utils implements Anvil.ViewFactory {
         }
     }
 
+    @Override
+    public View fromFactoryFunc(Context c, Anvil.FactoryFunc<? extends View> factoryFunc) {
+        View v =  factoryFunc.apply(c);
+        Class vClass = v.getClass();
+        createdViews.put(vClass, !createdViews.containsKey(vClass) ? 1 : (createdViews.get(vClass) + 1));
+        return Mockito.spy(v);
+    }
+
     public View fromClass(Context c, Class<? extends View> v) {
         try {
             createdViews.put(v, !createdViews.containsKey(v) ? 1 : (createdViews.get(v) + 1));
@@ -97,6 +105,13 @@ public class Utils implements Anvil.ViewFactory {
     }
 
     public static class MockView extends View {
+        public final static Anvil.FactoryFunc<MockView> FACTORY = new Anvil.FactoryFunc<MockView>() {
+            @Override
+            public MockView apply(Context context) {
+                return new MockView(context);
+            }
+        };
+
         public final Map<String, Object> props = new HashMap<>();
         public MockView(Context c) {
             super(c);
@@ -110,6 +125,13 @@ public class Utils implements Anvil.ViewFactory {
     }
 
     public static class MockLayout extends FrameLayout {
+        public final static Anvil.FactoryFunc<MockLayout> FACTORY = new Anvil.FactoryFunc<MockLayout>() {
+            @Override
+            public MockLayout apply(Context context) {
+                return new MockLayout(context);
+            }
+        };
+
         public final Map<String, Object> props = new HashMap<>();
         private List<View> children = new ArrayList<>();
 

--- a/anvil/src/test/java/trikita/anvil/ViewByIdTest.java
+++ b/anvil/src/test/java/trikita/anvil/ViewByIdTest.java
@@ -25,6 +25,12 @@ public class ViewByIdTest extends Utils {
             addView(firstView, 0);
             addView(secondView, 0);
         }
+        public final static Anvil.FactoryFunc<CustomLayout> FACTORY = new Anvil.FactoryFunc<CustomLayout>() {
+            @Override
+            public CustomLayout apply(Context context) {
+                return new CustomLayout(context);
+            }
+        };
     }
 
     @Test
@@ -32,6 +38,39 @@ public class ViewByIdTest extends Utils {
         Anvil.mount(container, new Anvil.Renderable() {
             public void view() {
                 v(CustomLayout.class, new Anvil.Renderable() {
+                    public void view() {
+                        // The order doesn't matter
+                        withId(ID_SECOND, new Anvil.Renderable() {
+                            public void view() {
+                                prop("baz", "qux");
+                            }
+                        });
+                        withId(ID_FIRST, new Anvil.Renderable() {
+                            public void view() {
+                                prop("foo", "bar");
+                            }
+                        });
+                        // Also, one view can be looked up by id many times
+                        withId(ID_SECOND, new Anvil.Renderable() {
+                            public void view() {
+                                prop("hello", "world");
+                            }
+                        });
+                    }
+                });
+            }
+        });
+        CustomLayout layout = (CustomLayout) container.getChildAt(0);
+        assertEquals("bar", layout.firstView.props.get("foo"));
+        assertEquals("qux", layout.secondView.props.get("baz"));
+        assertEquals("world", layout.secondView.props.get("hello"));
+    }
+
+    @Test
+    public void testWithIdWithFactoryFunc() {
+        Anvil.mount(container, new Anvil.Renderable() {
+            public void view() {
+                v(CustomLayout.FACTORY, new Anvil.Renderable() {
                     public void view() {
                         // The order doesn't matter
                         withId(ID_SECOND, new Anvil.Renderable() {

--- a/buildSrc/src/main/kotlin/trikita/anvilgen/DSLGeneratorTask.kt
+++ b/buildSrc/src/main/kotlin/trikita/anvilgen/DSLGeneratorTask.kt
@@ -160,6 +160,14 @@ open class DSLGeneratorTask : DefaultTask() {
         if (java.lang.reflect.Modifier.isAbstract(view.modifiers)) {
             return
         }
+        // Skip classes without single argument Context constructors
+        if (!view.constructors.isEmpty()) { // No constructors. Valid, since superclass should have the right one.
+            val contextConstructor = view.constructors.filter { it ->
+                it.parameterCount == 1 && it.parameters[0].type.canonicalName == "android.content.Context"
+            }.firstOrNull()
+            contextConstructor ?: return
+        }
+
         val className = view.canonicalName
         var name = view.simpleName
         val extension = project.extensions.getByName("anvilgen") as AnvilGenPluginExtension

--- a/buildSrc/src/main/kotlin/trikita/anvilgen/DSLGeneratorTask.kt
+++ b/buildSrc/src/main/kotlin/trikita/anvilgen/DSLGeneratorTask.kt
@@ -155,6 +155,11 @@ open class DSLGeneratorTask : DefaultTask() {
     // class, e.g. FrameLayout.class => frameLayout() { v(FrameLayout.class) }
     //
     fun processViews(builder: TypeSpec.Builder, view: Class<*>) {
+        // Skip abstract views.
+        // We shortcircuit it here, since we still want to generate attrs for these kinds of views.
+        if (java.lang.reflect.Modifier.isAbstract(view.modifiers)) {
+            return
+        }
         val className = view.canonicalName
         var name = view.simpleName
         val extension = project.extensions.getByName("anvilgen") as AnvilGenPluginExtension


### PR DESCRIPTION
This PR does:

- Adds ability to instantiate views using a factory function, instead of using constructor reflection.
This should also provide a bit more type safety. This is similar to how Anko works with `{ ctx -> View(ctx) }`
- Anvilgen now creates lazy factory functions for the above functionality.
- Anvilgen will skip creation of abstract views, but still generates attrs for them. This is a side-effect of the above type safety: could not instantiate abstract views.
- Anvilgen will skip creation of views which do not have constructor(Context). This is a side-effect of the above type safety: could not properly instantiate these views. In the past, `constructor.newInstance(context)` could have failed.

I haven't made any benchmarks yet, but I think this should provide some performance improvements versus `viewClass.getConstructor(Context.class).newInstance(c);`

Besides this, in Kotlin you get a rather nice syntax with `v(MyCustomView(it))`.

The only issue with this approach, that I could see, is that these functions should be cached, otherwise Anvil will reinstantiate the view on every render. Which is a pretty big deal.

Fortunately, Retrolambda and Kotlin caches lambdas, so this should work fine:
`v((ctx) -> { new MyCustomView(ctx) })`
and this
`v({ ctx -> MyCustomView(ctx) })`
and this
`v({ MyCustomView(it) })`

Kotlin (and maybe Retrolambda, didn't check), on the other hand, does not cache method references.
So while this is a pretty nice syntax:
`v(::MyCustomView) { 
      /* do something */
}`
the problem is that it would instantiate the view on every render.

Any thoughts?




