### PR TITLE
Not setting null on primitive parameters

### DIFF
--- a/anvil/src/main/java/trikita/anvil/PropertySetter.java
+++ b/anvil/src/main/java/trikita/anvil/PropertySetter.java
@@ -1,11 +1,11 @@
 package trikita.anvil;
 
-import android.view.View;
-
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.HashMap;
 import java.util.Map;
+
+import android.view.View;
 
 final class PropertySetter implements Anvil.AttributeSetter {
 
@@ -102,7 +102,7 @@ final class PropertySetter implements Anvil.AttributeSetter {
                     if ((m.getName().equals(setter) || m.getName().equals(listener)) &&
                             m.getParameterTypes().length == 1) {
                         Class arg = m.getParameterTypes()[0];
-                        if (value == null || assignable(arg, value.getClass())) {
+                        if ((value == null && !arg.isPrimitive()) || assignable(arg, value.getClass())) {
                             m.invoke(v, value);
                             return true;
                         }

--- a/anvil/src/main/java/trikita/anvil/PropertySetter.java
+++ b/anvil/src/main/java/trikita/anvil/PropertySetter.java
@@ -102,7 +102,7 @@ final class PropertySetter implements Anvil.AttributeSetter {
                     if ((m.getName().equals(setter) || m.getName().equals(listener)) &&
                             m.getParameterTypes().length == 1) {
                         Class arg = m.getParameterTypes()[0];
-                        if ((value == null && !arg.isPrimitive()) || assignable(arg, value.getClass())) {
+                        if ((value == null && !arg.isPrimitive()) || (value != null && assignable(arg, value.getClass()))) {
                             m.invoke(v, value);
                             return true;
                         }

--- a/anvil/src/main/java/trikita/anvil/PropertySetter.java
+++ b/anvil/src/main/java/trikita/anvil/PropertySetter.java
@@ -1,11 +1,11 @@
 package trikita.anvil;
 
+import android.view.View;
+
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.HashMap;
 import java.util.Map;
-
-import android.view.View;
 
 final class PropertySetter implements Anvil.AttributeSetter {
 


### PR DESCRIPTION
Some views on android, Like TextView has 2 methods to setText, one receiving int as parameter and other receiving String. 
This PR ensure that we are not sending null to methods that expect primitive parameters.

Fixes #107 