### PR TITLE
Update to newest Gradle, AGP, Kotlin and Android Support libs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,9 @@ android:
   licenses:
     - '.+'
 
+before_install:
+  - yes | sdkmanager "platforms;android-27"
+
 jdk:
   - oraclejdk8
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,11 @@ env:
 android:
   components:
     - tools
-    - build-tools-25.0.2
-    - android-25
+    - build-tools-27.0.3
+    - android-27
     - extra-android-m2repository
+  licenses:
+    - '.+'
 
 jdk:
   - oraclejdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ android:
     - android-27
     - extra-android-m2repository
   licenses:
-    - '.+'
+    - 'android-sdk-license-.+'
 
 before_install:
   - yes | sdkmanager "platforms;android-27"

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ android:
 
 before_install:
   - yes | sdkmanager "platforms;android-27"
+  - yes | sdkmanager "platforms;android-28"
 
 jdk:
   - oraclejdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@ android:
     - 'android-sdk-license-.+'
 
 before_install:
-  - yes | sdkmanager "platforms;android-27"
   - yes | sdkmanager "platforms;android-28"
 
 jdk:

--- a/anvil-appcompat-v7/build.gradle
+++ b/anvil-appcompat-v7/build.gradle
@@ -1,16 +1,16 @@
 buildscript {
 	dependencies {
-		classpath 'com.android.tools.build:gradle:2.2.3'
+		classpath "com.android.tools.build:gradle:$agp_version"
 		classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.5'
 	}
 }
 
 apply plugin: 'com.android.library'
 apply plugin: 'trikita.anvilgen'
+apply from: "$rootProject.projectDir/copyDeps.gradle"
 
 android {
-	compileSdkVersion 'android-25'
-	buildToolsVersion '25.0.2'
+	compileSdkVersion 27
 
 	compileOptions {
 		sourceCompatibility JavaVersion.VERSION_1_7
@@ -19,7 +19,9 @@ android {
 
 	defaultConfig {
 		minSdkVersion 15
-		targetSdkVersion 25
+		targetSdkVersion 27
+
+		missingDimensionStrategy 'api', 'sdk15'
 	}
 
 	lintOptions {
@@ -36,23 +38,25 @@ anvilgen {
 	type = "support"
 	libraryName = "appcompat-v7"
 	camelCaseName = "AppCompatv7"
-	version = "25.1.1"
+	version = support_version
 	dependencies = [
-	  "support-core-ui": [null],
-	  "support-core-utils": [null],
-	  "support-compat": [null],
-	  "support-media-compat": [null],
-	  "support-fragment": [null],
+	  "support-core-ui": null,
+	  "support-core-utils": null,
+	  "support-compat": null,
+	  "support-media-compat": null,
+	  "support-fragment": null,
+	  "viewmodel": "1.1.0",
+	  "android.arch.lifecycle-common":  "1.1.0",
 	]
 	quirks = QUIRKS
 }
 
 dependencies {
-	compile project(path: ':anvil', configuration: 'sdk15Release')
-	compile 'com.android.support:appcompat-v7:25.1.1'
+	implementation project(path: ':anvil')
+	implementation "com.android.support:appcompat-v7:$support_version"
 
-	testCompile 'junit:junit:4.12'
-	testCompile 'org.mockito:mockito-core:2.0.36-beta'
+	testImplementation 'junit:junit:4.12'
+	testImplementation "org.mockito:mockito-core:$mockito_version"
 }
 
 apply plugin: 'maven-publish'
@@ -143,8 +147,8 @@ artifacts {
 android.libraryVariants.all { variant ->
 	task("generate${variant.name.capitalize()}Javadoc", type: Javadoc) {
 		description "Generates Javadoc for $variant.name."
-		source = variant.javaCompile.source
+		source = variant.getCompileClasspath(null).getAsFileTree()
 		ext.androidJar = "${android.sdkDirectory}/platforms/${android.compileSdkVersion}/android.jar"
-		classpath = files(variant.javaCompile.classpath.files) + files(ext.androidJar)
+		classpath = files(variant.getCompileClasspath(null)) + files(ext.androidJar)
 	}
 }

--- a/anvil-appcompat-v7/src/main/java/trikita/anvil/appcompat/v7/AppCompatv7DSL.java
+++ b/anvil-appcompat-v7/src/main/java/trikita/anvil/appcompat/v7/AppCompatv7DSL.java
@@ -39,7 +39,6 @@ import android.support.v7.widget.FitWindowsFrameLayout;
 import android.support.v7.widget.FitWindowsLinearLayout;
 import android.support.v7.widget.FitWindowsViewGroup;
 import android.support.v7.widget.LinearLayoutCompat;
-import android.support.v7.widget.ListViewCompat;
 import android.support.v7.widget.ScrollingTabContainerView;
 import android.support.v7.widget.SearchView;
 import android.support.v7.widget.SwitchCompat;
@@ -295,14 +294,6 @@ public final class AppCompatv7DSL implements Anvil.AttributeSetter {
     return BaseDSL.v(LinearLayoutCompat.class, r);
   }
 
-  public static BaseDSL.ViewClassResult listViewCompat() {
-    return BaseDSL.v(ListViewCompat.class);
-  }
-
-  public static Void listViewCompat(Anvil.Renderable r) {
-    return BaseDSL.v(ListViewCompat.class, r);
-  }
-
   public static BaseDSL.ViewClassResult scrollingTabContainerView() {
     return BaseDSL.v(ScrollingTabContainerView.class);
   }
@@ -365,6 +356,10 @@ public final class AppCompatv7DSL implements Anvil.AttributeSetter {
 
   public static Void attachListener(ContentFrameLayout.OnAttachListener arg) {
     return BaseDSL.attr("attachListener", arg);
+  }
+
+  public static Void autoSizeTextTypeWithDefaults(int arg) {
+    return BaseDSL.attr("autoSizeTextTypeWithDefaults", arg);
   }
 
   public static Void baselineAligned(boolean arg) {
@@ -687,6 +682,14 @@ public final class AppCompatv7DSL implements Anvil.AttributeSetter {
     return BaseDSL.attr("supportButtonTintMode", arg);
   }
 
+  public static Void supportImageTintList(ColorStateList arg) {
+    return BaseDSL.attr("supportImageTintList", arg);
+  }
+
+  public static Void supportImageTintMode(PorterDuff.Mode arg) {
+    return BaseDSL.attr("supportImageTintMode", arg);
+  }
+
   public static Void switchMinWidth(int arg) {
     return BaseDSL.attr("switchMinWidth", arg);
   }
@@ -842,6 +845,16 @@ public final class AppCompatv7DSL implements Anvil.AttributeSetter {
       case "attachListener":
         if (v instanceof ContentFrameLayout && arg instanceof ContentFrameLayout.OnAttachListener) {
           ((ContentFrameLayout) v).setAttachListener((ContentFrameLayout.OnAttachListener) arg);
+          return true;
+        }
+        break;
+      case "autoSizeTextTypeWithDefaults":
+        if (v instanceof AppCompatButton && arg instanceof Integer) {
+          ((AppCompatButton) v).setAutoSizeTextTypeWithDefaults((int) arg);
+          return true;
+        }
+        if (v instanceof AppCompatTextView && arg instanceof Integer) {
+          ((AppCompatTextView) v).setAutoSizeTextTypeWithDefaults((int) arg);
           return true;
         }
         break;
@@ -1524,6 +1537,26 @@ public final class AppCompatv7DSL implements Anvil.AttributeSetter {
         }
         if (v instanceof AppCompatRadioButton && arg instanceof PorterDuff.Mode) {
           ((AppCompatRadioButton) v).setSupportButtonTintMode((PorterDuff.Mode) arg);
+          return true;
+        }
+        break;
+      case "supportImageTintList":
+        if (v instanceof AppCompatImageButton && arg instanceof ColorStateList) {
+          ((AppCompatImageButton) v).setSupportImageTintList((ColorStateList) arg);
+          return true;
+        }
+        if (v instanceof AppCompatImageView && arg instanceof ColorStateList) {
+          ((AppCompatImageView) v).setSupportImageTintList((ColorStateList) arg);
+          return true;
+        }
+        break;
+      case "supportImageTintMode":
+        if (v instanceof AppCompatImageButton && arg instanceof PorterDuff.Mode) {
+          ((AppCompatImageButton) v).setSupportImageTintMode((PorterDuff.Mode) arg);
+          return true;
+        }
+        if (v instanceof AppCompatImageView && arg instanceof PorterDuff.Mode) {
+          ((AppCompatImageView) v).setSupportImageTintMode((PorterDuff.Mode) arg);
           return true;
         }
         break;

--- a/anvil-cardview-v7/build.gradle
+++ b/anvil-cardview-v7/build.gradle
@@ -1,16 +1,16 @@
 buildscript {
 	dependencies {
-		classpath 'com.android.tools.build:gradle:2.2.3'
+		classpath "com.android.tools.build:gradle:$agp_version"
 		classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.5'
 	}
 }
 
 apply plugin: 'com.android.library'
 apply plugin: 'trikita.anvilgen'
+apply from: "$rootProject.projectDir/copyDeps.gradle"
 
 android {
-	compileSdkVersion 'android-25'
-	buildToolsVersion '25.0.2'
+	compileSdkVersion 27
 
 	compileOptions {
 		sourceCompatibility JavaVersion.VERSION_1_7
@@ -19,7 +19,9 @@ android {
 
 	defaultConfig {
 		minSdkVersion 15
-		targetSdkVersion 25
+		targetSdkVersion 27
+
+		missingDimensionStrategy 'api', 'sdk15'
 	}
 
 	lintOptions {
@@ -36,17 +38,17 @@ anvilgen {
 	type = "support"
 	libraryName = "cardview-v7"
 	camelCaseName = "CardViewv7"
-	version = "25.1.1"
-	dependencies = ["cardview-v7": ["libs/internal_impl-$version".toString()]]
+	version = support_version
+	dependencies = ["cardview-v7": null]
 	quirks = QUIRKS
 }
 
 dependencies {
-	compile project(path: ':anvil', configuration: 'sdk15Release')
-	compile 'com.android.support:cardview-v7:25.1.1'
+	implementation project(path: ':anvil')
+	implementation "com.android.support:cardview-v7:$support_version"
 
-	testCompile 'junit:junit:4.12'
-	testCompile 'org.mockito:mockito-core:2.0.36-beta'
+	testImplementation 'junit:junit:4.12'
+	testImplementation "org.mockito:mockito-core:$mockito_version"
 }
 
 apply plugin: 'maven-publish'
@@ -137,8 +139,8 @@ artifacts {
 android.libraryVariants.all { variant ->
 	task("generate${variant.name.capitalize()}Javadoc", type: Javadoc) {
 		description "Generates Javadoc for $variant.name."
-		source = variant.javaCompile.source
+		source = variant.getCompileClasspath(null).getAsFileTree()
 		ext.androidJar = "${android.sdkDirectory}/platforms/${android.compileSdkVersion}/android.jar"
-		classpath = files(variant.javaCompile.classpath.files) + files(ext.androidJar)
+		classpath = files(variant.getCompileClasspath(null)) + files(ext.androidJar)
 	}
 }

--- a/anvil-design/build.gradle
+++ b/anvil-design/build.gradle
@@ -1,16 +1,16 @@
 buildscript {
 	dependencies {
-		classpath 'com.android.tools.build:gradle:2.2.3'
+		classpath "com.android.tools.build:gradle:$agp_version"
 		classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.5'
 	}
 }
 
 apply plugin: 'com.android.library'
 apply plugin: 'trikita.anvilgen'
+apply from: "$rootProject.projectDir/copyDeps.gradle"
 
 android {
-	compileSdkVersion 'android-25'
-	buildToolsVersion '25.0.2'
+	compileSdkVersion 27
 
 	compileOptions {
 		sourceCompatibility JavaVersion.VERSION_1_7
@@ -19,7 +19,9 @@ android {
 
 	defaultConfig {
 		minSdkVersion 15
-		targetSdkVersion 25
+		targetSdkVersion 27
+
+		missingDimensionStrategy 'api', 'sdk15'
 	}
 
 	lintOptions {
@@ -36,26 +38,28 @@ anvilgen {
 	type = "support"
 	libraryName = "design"
 	camelCaseName = "Design"
-	version = "25.1.1"
+	version = support_version
 	dependencies = [
-	  "support-core-ui": [null],
-	  "support-core-utils": [null],
-	  "support-compat": [null],
-	  "support-media-compat": [null],
-	  "support-fragment": [null],
-	  "transition": [null],
-		"appcompat-v7": [null],
-		"recyclerview-v7": [null]
+	  "support-core-ui": null,
+	  "support-core-utils": null,
+	  "support-compat": null,
+	  "support-media-compat": null,
+	  "support-fragment": null,
+	  "transition": null,
+	  "appcompat-v7": null,
+	  "recyclerview-v7": null,
+	  "android.arch.lifecycle-common": "1.1.0",
+	  "viewmodel": "1.1.0"
 	]
 	quirks = QUIRKS
 }
 
 dependencies {
-	compile project(path: ':anvil', configuration: 'sdk15Release')
-	compile 'com.android.support:design:25.1.1'
+	implementation project(path: ':anvil')
+	implementation "com.android.support:design:$support_version"
 
-	testCompile 'junit:junit:4.12'
-	testCompile 'org.mockito:mockito-core:2.0.36-beta'
+	testImplementation 'junit:junit:4.12'
+	testImplementation "org.mockito:mockito-core:$mockito_version"
 }
 
 apply plugin: 'maven-publish'
@@ -146,8 +150,8 @@ artifacts {
 android.libraryVariants.all { variant ->
 	task("generate${variant.name.capitalize()}Javadoc", type: Javadoc) {
 		description "Generates Javadoc for $variant.name."
-		source = variant.javaCompile.source
+		source = variant.getCompileClasspath(null).getAsFileTree()
 		ext.androidJar = "${android.sdkDirectory}/platforms/${android.compileSdkVersion}/android.jar"
-		classpath = files(variant.javaCompile.classpath.files) + files(ext.androidJar)
+		classpath = files(variant.getCompileClasspath(null)) + files(ext.androidJar)
 	}
 }

--- a/anvil-design/src/main/java/trikita/anvil/design/DesignDSL.java
+++ b/anvil-design/src/main/java/trikita/anvil/design/DesignDSL.java
@@ -17,7 +17,6 @@ import android.support.design.widget.AppBarLayout;
 import android.support.design.widget.BottomNavigationView;
 import android.support.design.widget.CheckableImageButton;
 import android.support.design.widget.CollapsingToolbarLayout;
-import android.support.design.widget.CoordinatorLayout;
 import android.support.design.widget.FloatingActionButton;
 import android.support.design.widget.NavigationView;
 import android.support.design.widget.TabItem;
@@ -145,14 +144,6 @@ public final class DesignDSL implements Anvil.AttributeSetter {
     return BaseDSL.v(CollapsingToolbarLayout.class, r);
   }
 
-  public static BaseDSL.ViewClassResult coordinatorLayout() {
-    return BaseDSL.v(CoordinatorLayout.class);
-  }
-
-  public static Void coordinatorLayout(Anvil.Renderable r) {
-    return BaseDSL.v(CoordinatorLayout.class, r);
-  }
-
   public static BaseDSL.ViewClassResult floatingActionButton() {
     return BaseDSL.v(FloatingActionButton.class);
   }
@@ -199,14 +190,6 @@ public final class DesignDSL implements Anvil.AttributeSetter {
 
   public static Void textInputLayout(Anvil.Renderable r) {
     return BaseDSL.v(TextInputLayout.class, r);
-  }
-
-  public static Void backgroundTintList(ColorStateList arg) {
-    return BaseDSL.attr("backgroundTintList", arg);
-  }
-
-  public static Void backgroundTintMode(PorterDuff.Mode arg) {
-    return BaseDSL.attr("backgroundTintMode", arg);
   }
 
   public static Void checkable(boolean arg) {
@@ -265,6 +248,10 @@ public final class DesignDSL implements Anvil.AttributeSetter {
     return BaseDSL.attr("counterMaxLength", arg);
   }
 
+  public static Void customSize(int arg) {
+    return BaseDSL.attr("customSize", arg);
+  }
+
   public static Void error(CharSequence arg) {
     return BaseDSL.attr("error", arg);
   }
@@ -315,14 +302,6 @@ public final class DesignDSL implements Anvil.AttributeSetter {
 
   public static Void expandedTitleTypeface(Typeface arg) {
     return BaseDSL.attr("expandedTitleTypeface", arg);
-  }
-
-  public static Void foreground(Drawable arg) {
-    return BaseDSL.attr("foreground", arg);
-  }
-
-  public static Void foregroundGravity(int arg) {
-    return BaseDSL.attr("foregroundGravity", arg);
   }
 
   public static Void hint(CharSequence arg) {
@@ -389,6 +368,10 @@ public final class DesignDSL implements Anvil.AttributeSetter {
     return BaseDSL.attr("needsEmptyIcon", arg);
   }
 
+  public static Void onNavigationItemReselected(BottomNavigationView.OnNavigationItemReselectedListener arg) {
+    return BaseDSL.attr("onNavigationItemReselected", arg);
+  }
+
   public static Void onNavigationItemSelected(BottomNavigationView.OnNavigationItemSelectedListener arg) {
     return BaseDSL.attr("onNavigationItemSelected", arg);
   }
@@ -441,6 +424,10 @@ public final class DesignDSL implements Anvil.AttributeSetter {
     return BaseDSL.attr("scrimsShown", arg);
   }
 
+  public static Void selectedItemId(int arg) {
+    return BaseDSL.attr("selectedItemId", arg);
+  }
+
   public static Void selectedTabIndicatorColor(int arg) {
     return BaseDSL.attr("selectedTabIndicatorColor", arg);
   }
@@ -455,18 +442,6 @@ public final class DesignDSL implements Anvil.AttributeSetter {
 
   public static Void size(int arg) {
     return BaseDSL.attr("size", arg);
-  }
-
-  public static Void statusBarBackground(Drawable arg) {
-    return BaseDSL.attr("statusBarBackground", arg);
-  }
-
-  public static Void statusBarBackgroundColor(int arg) {
-    return BaseDSL.attr("statusBarBackgroundColor", arg);
-  }
-
-  public static Void statusBarBackgroundResource(int arg) {
-    return BaseDSL.attr("statusBarBackgroundResource", arg);
   }
 
   public static Void statusBarScrim(Drawable arg) {
@@ -523,18 +498,6 @@ public final class DesignDSL implements Anvil.AttributeSetter {
 
   public boolean set(View v, String name, final Object arg, final Object old) {
     switch (name) {
-      case "backgroundTintList":
-        if (v instanceof FloatingActionButton && arg instanceof ColorStateList) {
-          ((FloatingActionButton) v).setBackgroundTintList((ColorStateList) arg);
-          return true;
-        }
-        break;
-      case "backgroundTintMode":
-        if (v instanceof FloatingActionButton && arg instanceof PorterDuff.Mode) {
-          ((FloatingActionButton) v).setBackgroundTintMode((PorterDuff.Mode) arg);
-          return true;
-        }
-        break;
       case "checkable":
         if (v instanceof BottomNavigationItemView && arg instanceof Boolean) {
           ((BottomNavigationItemView) v).setCheckable((boolean) arg);
@@ -629,6 +592,12 @@ public final class DesignDSL implements Anvil.AttributeSetter {
           return true;
         }
         break;
+      case "customSize":
+        if (v instanceof FloatingActionButton && arg instanceof Integer) {
+          ((FloatingActionButton) v).setCustomSize((int) arg);
+          return true;
+        }
+        break;
       case "error":
         if (v instanceof TextInputLayout && arg instanceof CharSequence) {
           ((TextInputLayout) v).setError((CharSequence) arg);
@@ -704,18 +673,6 @@ public final class DesignDSL implements Anvil.AttributeSetter {
       case "expandedTitleTypeface":
         if (v instanceof CollapsingToolbarLayout && arg instanceof Typeface) {
           ((CollapsingToolbarLayout) v).setExpandedTitleTypeface((Typeface) arg);
-          return true;
-        }
-        break;
-      case "foreground":
-        if (v instanceof ForegroundLinearLayout && arg instanceof Drawable) {
-          ((ForegroundLinearLayout) v).setForeground((Drawable) arg);
-          return true;
-        }
-        break;
-      case "foregroundGravity":
-        if (v instanceof ForegroundLinearLayout && arg instanceof Integer) {
-          ((ForegroundLinearLayout) v).setForegroundGravity((int) arg);
           return true;
         }
         break;
@@ -837,6 +794,21 @@ public final class DesignDSL implements Anvil.AttributeSetter {
           return true;
         }
         break;
+      case "onNavigationItemReselected":
+        if (v instanceof BottomNavigationView && arg instanceof BottomNavigationView.OnNavigationItemReselectedListener) {
+          if (arg != null) {
+            ((BottomNavigationView) v).setOnNavigationItemReselectedListener(new BottomNavigationView.OnNavigationItemReselectedListener() {
+              public void onNavigationItemReselected(MenuItem a0) {
+                ((BottomNavigationView.OnNavigationItemReselectedListener) arg).onNavigationItemReselected(a0);
+                Anvil.render();
+              }
+            });
+          } else {
+            ((BottomNavigationView) v).setOnNavigationItemReselectedListener((BottomNavigationView.OnNavigationItemReselectedListener) null);
+          }
+          return true;
+        }
+        break;
       case "onNavigationItemSelected":
         if (v instanceof BottomNavigationView && arg instanceof BottomNavigationView.OnNavigationItemSelectedListener) {
           if (arg != null) {
@@ -921,6 +893,12 @@ public final class DesignDSL implements Anvil.AttributeSetter {
           return true;
         }
         break;
+      case "selectedItemId":
+        if (v instanceof BottomNavigationView && arg instanceof Integer) {
+          ((BottomNavigationView) v).setSelectedItemId((int) arg);
+          return true;
+        }
+        break;
       case "selectedTabIndicatorColor":
         if (v instanceof TabLayout && arg instanceof Integer) {
           ((TabLayout) v).setSelectedTabIndicatorColor((int) arg);
@@ -942,24 +920,6 @@ public final class DesignDSL implements Anvil.AttributeSetter {
       case "size":
         if (v instanceof FloatingActionButton && arg instanceof Integer) {
           ((FloatingActionButton) v).setSize((int) arg);
-          return true;
-        }
-        break;
-      case "statusBarBackground":
-        if (v instanceof CoordinatorLayout && arg instanceof Drawable) {
-          ((CoordinatorLayout) v).setStatusBarBackground((Drawable) arg);
-          return true;
-        }
-        break;
-      case "statusBarBackgroundColor":
-        if (v instanceof CoordinatorLayout && arg instanceof Integer) {
-          ((CoordinatorLayout) v).setStatusBarBackgroundColor((int) arg);
-          return true;
-        }
-        break;
-      case "statusBarBackgroundResource":
-        if (v instanceof CoordinatorLayout && arg instanceof Integer) {
-          ((CoordinatorLayout) v).setStatusBarBackgroundResource((int) arg);
           return true;
         }
         break;

--- a/anvil-gridlayout-v7/build.gradle
+++ b/anvil-gridlayout-v7/build.gradle
@@ -1,16 +1,16 @@
 buildscript {
 	dependencies {
-		classpath 'com.android.tools.build:gradle:2.2.3'
+		classpath "com.android.tools.build:gradle:$agp_version"
 		classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.5'
 	}
 }
 
 apply plugin: 'com.android.library'
 apply plugin: 'trikita.anvilgen'
+apply from: "$rootProject.projectDir/copyDeps.gradle"
 
 android {
-	compileSdkVersion 'android-25'
-	buildToolsVersion '25.0.2'
+	compileSdkVersion 27
 
 	compileOptions {
 		sourceCompatibility JavaVersion.VERSION_1_7
@@ -19,7 +19,9 @@ android {
 
 	defaultConfig {
 		minSdkVersion 15
-		targetSdkVersion 25
+		targetSdkVersion 27
+
+		missingDimensionStrategy 'api', 'sdk15'
 	}
 
 	lintOptions {
@@ -36,23 +38,23 @@ anvilgen {
 	type = "support"
 	libraryName = "gridlayout-v7"
 	camelCaseName = "GridLayoutv7"
-	version = "25.1.1"
+	version = support_version
 	dependencies = [
-	  "support-core-ui": [null],
-	  "support-core-utils": [null],
-	  "support-compat": [null],
-	  "support-media-compat": [null],
-	  "support-fragment": [null],
+	  "support-core-ui": null,
+	  "support-core-utils": null,
+	  "support-compat": null,
+	  "support-media-compat": null,
+	  "support-fragment": null,
 	]
 	quirks = QUIRKS
 }
 
 dependencies {
-	compile project(path: ':anvil', configuration: 'sdk15Release')
-	compile 'com.android.support:gridlayout-v7:25.1.1'
+	implementation project(path: ':anvil')
+	implementation "com.android.support:gridlayout-v7:$support_version"
 
-	testCompile 'junit:junit:4.12'
-	testCompile 'org.mockito:mockito-core:2.0.36-beta'
+	testImplementation 'junit:junit:4.12'
+	testImplementation "org.mockito:mockito-core:$mockito_version"
 }
 
 apply plugin: 'maven-publish'
@@ -143,8 +145,8 @@ artifacts {
 android.libraryVariants.all { variant ->
 	task("generate${variant.name.capitalize()}Javadoc", type: Javadoc) {
 		description "Generates Javadoc for $variant.name."
-		source = variant.javaCompile.source
+		source = variant.getCompileClasspath(null).getAsFileTree()
 		ext.androidJar = "${android.sdkDirectory}/platforms/${android.compileSdkVersion}/android.jar"
-		classpath = files(variant.javaCompile.classpath.files) + files(ext.androidJar)
+		classpath = files(variant.getCompileClasspath(null)) + files(ext.androidJar)
 	}
 }

--- a/anvil-recyclerview-v7/build.gradle
+++ b/anvil-recyclerview-v7/build.gradle
@@ -1,16 +1,16 @@
 buildscript {
 	dependencies {
-		classpath 'com.android.tools.build:gradle:2.2.3'
+		classpath "com.android.tools.build:gradle:$agp_version"
 		classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.5'
 	}
 }
 
 apply plugin: 'com.android.library'
 apply plugin: 'trikita.anvilgen'
+apply from: "$rootProject.projectDir/copyDeps.gradle"
 
 android {
-	compileSdkVersion 'android-25'
-	buildToolsVersion '25.0.2'
+	compileSdkVersion 27
 
 	compileOptions {
 		sourceCompatibility JavaVersion.VERSION_1_7
@@ -19,7 +19,9 @@ android {
 
 	defaultConfig {
 		minSdkVersion 15
-		targetSdkVersion 25
+		targetSdkVersion 27
+
+		missingDimensionStrategy 'api', 'sdk15'
 	}
 
 	lintOptions {
@@ -36,24 +38,24 @@ anvilgen {
 	type = "support"
 	libraryName = "recyclerview-v7"
 	camelCaseName = "RecyclerViewv7"
-	version = "25.1.1"
+	version = support_version
 	dependencies = [
-	  "support-core-ui": [null],
-	  "support-core-utils": [null],
-	  "support-compat": [null],
-	  "support-media-compat": [null],
-	  "support-fragment": [null],
+	  "support-core-ui": null,
+	  "support-core-utils": null,
+	  "support-compat": null,
+	  "support-media-compat": null,
+	  "support-fragment": null,
 	]
 	quirks = QUIRKS
 	superclass = "BaseRecyclerView"
 }
 
 dependencies {
-	compile project(path: ':anvil', configuration: 'sdk15Release')
-	compile 'com.android.support:recyclerview-v7:25.1.1'
+	implementation project(path: ':anvil')
+	implementation "com.android.support:recyclerview-v7:$support_version"
 
-	testCompile 'junit:junit:4.12'
-	testCompile 'org.mockito:mockito-core:2.0.36-beta'
+	testImplementation 'junit:junit:4.12'
+	testImplementation "org.mockito:mockito-core:$mockito_version"
 }
 
 apply plugin: 'maven-publish'
@@ -144,8 +146,8 @@ artifacts {
 android.libraryVariants.all { variant ->
 	task("generate${variant.name.capitalize()}Javadoc", type: Javadoc) {
 		description "Generates Javadoc for $variant.name."
-		source = variant.javaCompile.source
+		source = variant.getCompileClasspath(null).getAsFileTree()
 		ext.androidJar = "${android.sdkDirectory}/platforms/${android.compileSdkVersion}/android.jar"
-		classpath = files(variant.javaCompile.classpath.files) + files(ext.androidJar)
+		classpath = files(variant.getCompileClasspath(null)) + files(ext.androidJar)
 	}
 }

--- a/anvil-recyclerview-v7/src/main/java/trikita/anvil/recyclerview/v7/RecyclerViewv7DSL.java
+++ b/anvil-recyclerview-v7/src/main/java/trikita/anvil/recyclerview/v7/RecyclerViewv7DSL.java
@@ -42,6 +42,10 @@ public final class RecyclerViewv7DSL extends BaseRecyclerView implements Anvil.A
     return BaseDSL.attr("childDrawingOrderCallback", arg);
   }
 
+  public static Void edgeEffectFactory(RecyclerView.EdgeEffectFactory arg) {
+    return BaseDSL.attr("edgeEffectFactory", arg);
+  }
+
   public static Void hasFixedSize(boolean arg) {
     return BaseDSL.attr("hasFixedSize", arg);
   }
@@ -60,10 +64,6 @@ public final class RecyclerViewv7DSL extends BaseRecyclerView implements Anvil.A
 
   public static Void layoutManager(RecyclerView.LayoutManager arg) {
     return BaseDSL.attr("layoutManager", arg);
-  }
-
-  public static Void nestedScrollingEnabled(boolean arg) {
-    return BaseDSL.attr("nestedScrollingEnabled", arg);
   }
 
   public static Void onFling(RecyclerView.OnFlingListener arg) {
@@ -110,6 +110,12 @@ public final class RecyclerViewv7DSL extends BaseRecyclerView implements Anvil.A
           return true;
         }
         break;
+      case "edgeEffectFactory":
+        if (v instanceof RecyclerView && arg instanceof RecyclerView.EdgeEffectFactory) {
+          ((RecyclerView) v).setEdgeEffectFactory((RecyclerView.EdgeEffectFactory) arg);
+          return true;
+        }
+        break;
       case "hasFixedSize":
         if (v instanceof RecyclerView && arg instanceof Boolean) {
           ((RecyclerView) v).setHasFixedSize((boolean) arg);
@@ -137,12 +143,6 @@ public final class RecyclerViewv7DSL extends BaseRecyclerView implements Anvil.A
       case "layoutManager":
         if (v instanceof RecyclerView && arg instanceof RecyclerView.LayoutManager) {
           ((RecyclerView) v).setLayoutManager((RecyclerView.LayoutManager) arg);
-          return true;
-        }
-        break;
-      case "nestedScrollingEnabled":
-        if (v instanceof RecyclerView && arg instanceof Boolean) {
-          ((RecyclerView) v).setNestedScrollingEnabled((boolean) arg);
           return true;
         }
         break;

--- a/anvil-support-v4/build.gradle
+++ b/anvil-support-v4/build.gradle
@@ -1,16 +1,16 @@
 buildscript {
 	dependencies {
-		classpath 'com.android.tools.build:gradle:2.2.3'
+		classpath "com.android.tools.build:gradle:$agp_version"
 		classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.5'
 	}
 }
 
 apply plugin: 'com.android.library'
 apply plugin: 'trikita.anvilgen'
+apply from: "$rootProject.projectDir/copyDeps.gradle"
 
 android {
-	compileSdkVersion 'android-25'
-	buildToolsVersion '25.0.2'
+	compileSdkVersion 27
 
 	compileOptions {
 		sourceCompatibility JavaVersion.VERSION_1_7
@@ -19,7 +19,9 @@ android {
 
 	defaultConfig {
 		minSdkVersion 15
-		targetSdkVersion 25
+		targetSdkVersion 27
+
+		missingDimensionStrategy 'api', 'sdk15'
 	}
 
 	lintOptions {
@@ -36,29 +38,29 @@ anvilgen {
 	type = "support"
 	libraryName = "support-core-ui"
 	camelCaseName = "SupportCoreUi"
-	version = "25.1.1"
+	version = support_version
 	dependencies = [
-	  "support-core-ui": [null],
-	  "support-core-utils": [null],
-	  "support-compat": [null],
-	  "support-media-compat": [null],
-	  "support-fragment": [null],
-	  "support-v4": [null, "libs/internal_impl-$version".toString()],
+	  "support-core-ui": null,
+	  "support-core-utils": null,
+	  "support-compat": null,
+	  "support-media-compat": null,
+	  "support-fragment": null,
+	  "support-v4": null
 	]
 	quirks = QUIRKS
 }
 
 dependencies {
-	compile project(path: ':anvil', configuration: 'sdk15Release')
-	compile 'com.android.support:support-core-ui:25.1.1'
-	compile 'com.android.support:support-core-utils:25.1.1'
-	compile 'com.android.support:support-compat:25.1.1'
-	compile 'com.android.support:support-media-compat:25.1.1'
-	compile 'com.android.support:support-fragment:25.1.1'
-	compile 'com.android.support:transition:25.1.1'
+	implementation project(path : ':anvil')
+	implementation "com.android.support:support-core-ui:$support_version"
+	implementation "com.android.support:support-core-utils:$support_version"
+	implementation "com.android.support:support-compat:$support_version"
+	implementation "com.android.support:support-media-compat:$support_version"
+	implementation "com.android.support:support-fragment:$support_version"
+	implementation "com.android.support:transition:$support_version"
 
-	testCompile 'junit:junit:4.12'
-	testCompile 'org.mockito:mockito-core:2.0.36-beta'
+	testImplementation 'junit:junit:4.12'
+	testImplementation "org.mockito:mockito-core:$mockito_version"
 }
 
 apply plugin: 'maven-publish'
@@ -149,8 +151,8 @@ artifacts {
 android.libraryVariants.all { variant ->
 	task("generate${variant.name.capitalize()}Javadoc", type: Javadoc) {
 		description "Generates Javadoc for $variant.name."
-		source = variant.javaCompile.source
+		source = variant.getCompileClasspath(null).getAsFileTree()
 		ext.androidJar = "${android.sdkDirectory}/platforms/${android.compileSdkVersion}/android.jar"
-		classpath = files(variant.javaCompile.classpath.files) + files(ext.androidJar)
+		classpath = files(variant.getCompileClasspath(null)) + files(ext.androidJar)
 	}
 }

--- a/anvil-support-v4/src/main/java/trikita/anvil/support/core/ui/SupportCoreUiDSL.java
+++ b/anvil-support-v4/src/main/java/trikita/anvil/support/core/ui/SupportCoreUiDSL.java
@@ -1,6 +1,7 @@
 package trikita.anvil.support.core.ui;
 
 import android.graphics.drawable.Drawable;
+import android.support.design.widget.CoordinatorLayout;
 import android.support.v4.view.PagerAdapter;
 import android.support.v4.view.PagerTabStrip;
 import android.support.v4.view.PagerTitleStrip;
@@ -30,6 +31,14 @@ import trikita.anvil.BaseDSL;
 public final class SupportCoreUiDSL implements Anvil.AttributeSetter {
   static {
     Anvil.registerAttributeSetter(new SupportCoreUiDSL());
+  }
+
+  public static BaseDSL.ViewClassResult coordinatorLayout() {
+    return BaseDSL.v(CoordinatorLayout.class);
+  }
+
+  public static Void coordinatorLayout(Anvil.Renderable r) {
+    return BaseDSL.v(CoordinatorLayout.class, r);
   }
 
   public static BaseDSL.ViewClassResult pagerTabStrip() {
@@ -148,10 +157,6 @@ public final class SupportCoreUiDSL implements Anvil.AttributeSetter {
     return BaseDSL.attr("gravity", arg);
   }
 
-  public static Void nestedScrollingEnabled(boolean arg) {
-    return BaseDSL.attr("nestedScrollingEnabled", arg);
-  }
-
   public static Void nonPrimaryAlpha(float arg) {
     return BaseDSL.attr("nonPrimaryAlpha", arg);
   }
@@ -248,6 +253,10 @@ public final class SupportCoreUiDSL implements Anvil.AttributeSetter {
     return BaseDSL.attr("statusBarBackgroundColor", arg);
   }
 
+  public static Void statusBarBackgroundResource(int arg) {
+    return BaseDSL.attr("statusBarBackgroundResource", arg);
+  }
+
   public static Void tabIndicatorColor(int arg) {
     return BaseDSL.attr("tabIndicatorColor", arg);
   }
@@ -329,16 +338,6 @@ public final class SupportCoreUiDSL implements Anvil.AttributeSetter {
       case "gravity":
         if (v instanceof PagerTitleStrip && arg instanceof Integer) {
           ((PagerTitleStrip) v).setGravity((int) arg);
-          return true;
-        }
-        break;
-      case "nestedScrollingEnabled":
-        if (v instanceof NestedScrollView && arg instanceof Boolean) {
-          ((NestedScrollView) v).setNestedScrollingEnabled((boolean) arg);
-          return true;
-        }
-        if (v instanceof SwipeRefreshLayout && arg instanceof Boolean) {
-          ((SwipeRefreshLayout) v).setNestedScrollingEnabled((boolean) arg);
           return true;
         }
         break;
@@ -485,6 +484,10 @@ public final class SupportCoreUiDSL implements Anvil.AttributeSetter {
         }
         break;
       case "statusBarBackground":
+        if (v instanceof CoordinatorLayout && arg instanceof Drawable) {
+          ((CoordinatorLayout) v).setStatusBarBackground((Drawable) arg);
+          return true;
+        }
         if (v instanceof DrawerLayout && arg instanceof Drawable) {
           ((DrawerLayout) v).setStatusBarBackground((Drawable) arg);
           return true;
@@ -495,8 +498,18 @@ public final class SupportCoreUiDSL implements Anvil.AttributeSetter {
         }
         break;
       case "statusBarBackgroundColor":
+        if (v instanceof CoordinatorLayout && arg instanceof Integer) {
+          ((CoordinatorLayout) v).setStatusBarBackgroundColor((int) arg);
+          return true;
+        }
         if (v instanceof DrawerLayout && arg instanceof Integer) {
           ((DrawerLayout) v).setStatusBarBackgroundColor((int) arg);
+          return true;
+        }
+        break;
+      case "statusBarBackgroundResource":
+        if (v instanceof CoordinatorLayout && arg instanceof Integer) {
+          ((CoordinatorLayout) v).setStatusBarBackgroundResource((int) arg);
           return true;
         }
         break;

--- a/anvil/build.gradle
+++ b/anvil/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
 	dependencies {
-		classpath 'com.android.tools.build:gradle:2.2.3'
+		classpath "com.android.tools.build:gradle:$agp_version"
 		classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.5'
 	}
 }
@@ -9,8 +9,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'trikita.anvilgen'
 
 android {
-	compileSdkVersion 'android-25'
-	buildToolsVersion '25.0.2'
+	compileSdkVersion 27
 
 	compileOptions {
 		sourceCompatibility JavaVersion.VERSION_1_7
@@ -19,14 +18,14 @@ android {
 
 	defaultConfig {
 		minSdkVersion 15
-		targetSdkVersion 25
+		targetSdkVersion 27
 	}
 
 	lintOptions {
 		abortOnError false
 	}
 
-	publishNonDefault true
+	flavorDimensions "api"
 	productFlavors {
 		sdk15 {
 			minSdkVersion 15
@@ -51,8 +50,8 @@ anvilgen {
 }
 
 dependencies {
-	testCompile 'junit:junit:4.12'
-	testCompile 'org.mockito:mockito-core:2.0.43-beta'
+	testImplementation 'junit:junit:4.12'
+	testImplementation "org.mockito:mockito-core:$mockito_version"
 }
 
 apply plugin: 'maven-publish'
@@ -161,8 +160,8 @@ artifacts {
 android.libraryVariants.all { variant ->
 	task("generate${variant.name.capitalize()}Javadoc", type: Javadoc) {
 		description "Generates Javadoc for $variant.name."
-		source = variant.javaCompile.source
+		source = variant.getCompileClasspath(null).getAsFileTree()
 		ext.androidJar = "${android.sdkDirectory}/platforms/${android.compileSdkVersion}/android.jar"
-		classpath = files(variant.javaCompile.classpath.files) + files(ext.androidJar)
+		classpath = files(variant.getCompileClasspath(null)) + files(ext.androidJar)
 	}
 }

--- a/anvil/src/main/java/trikita/anvil/Anvil.java
+++ b/anvil/src/main/java/trikita/anvil/Anvil.java
@@ -316,7 +316,9 @@ public final class Anvil {
                     }
                 }
                 indices.pop();
-                views.pop();
+                if (v != null){
+                    views.pop();
+                }
             }
 
             <T> void attr(String name, T value) {

--- a/build.gradle
+++ b/build.gradle
@@ -1,12 +1,20 @@
 subprojects {
+    ext {
+        mockito_version = '2.23.0'
+        support_version = '27.1.1'
+        agp_version = '3.3.2'
+    }
+
     buildscript {
         repositories {
+            google()
             jcenter()
         }
     }
 
     repositories {
         mavenLocal()
+        google()
         jcenter()
     }
 

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.0.2'
+    ext.kotlin_version = '1.3.21'
 
     repositories {
         mavenCentral()
@@ -19,8 +19,8 @@ repositories {
 dependencies {
     compile gradleApi()
 
-    compile "org.jetbrains.kotlin:kotlin-stdlib:1.0.0"
-    compile "org.jetbrains.kotlin:kotlin-reflect:1.0.2"
+    compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    compile "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
 
     compile 'com.squareup:javapoet:1.7.0'
 }

--- a/buildSrc/src/main/kotlin/trikita/anvilgen/AnvilGenPluginExtension.kt
+++ b/buildSrc/src/main/kotlin/trikita/anvilgen/AnvilGenPluginExtension.kt
@@ -6,6 +6,6 @@ open class AnvilGenPluginExtension {
     var camelCaseName = ""
     var version = ""
     var quirks = mutableMapOf<String, Map<String, Any>>()
-    var dependencies = mutableMapOf<String, List<String>>()
+    var dependencies = mutableMapOf<String, String?>()
     var superclass = ""
 }

--- a/copyDeps.gradle
+++ b/copyDeps.gradle
@@ -1,0 +1,48 @@
+/**
+ * Taken from https://gist.github.com/n-belokopytov/d44949590748b096c1a497008b761d04
+ */
+android.libraryVariants.all { variant ->
+    task "copyDependencies${variant.name.capitalize()}"() {
+        outputs.upToDateWhen { false }
+        doLast {
+            println "Executing copyDependencies${variant.name.capitalize()}"
+            variant.getCompileClasspath().each { fileDependency ->
+                def sourcePath = fileDependency.absolutePath
+                def destinationPath = project.projectDir.path + "/build/dependencies/${variant.name}/"
+                println "Copying dependency:"
+                println sourcePath
+
+                //The monstrous regex that gets the name of the lib from it’s exploded .aar path
+                def dependencyName
+                if (sourcePath.contains("classes.jar")) {
+                    def dependencyAarNameRegexResult = (sourcePath =~ /.*\/(.*)\.aar\/.*\/jars\/classes\.jar/)
+                    if (dependencyAarNameRegexResult.size() > 0) {
+                        dependencyName = dependencyAarNameRegexResult[0][1]
+                        println "Exploded AAR found : ${dependencyName}"
+                    }
+                } else {
+                    def dependencyJarNameRegexResult = (sourcePath =~ /.*\/caches\/[^\/]+\/[^\/]+\/(.*)\/.*\/.*\.jar/)
+                    if (dependencyJarNameRegexResult.size() > 0) {
+                        dependencyName = (dependencyJarNameRegexResult[0][1]).replace("/","-")
+                        println "Jar found : ${dependencyName}"
+                    }
+                }
+
+
+                copy {
+                    from sourcePath
+                    into destinationPath
+
+                    rename { String filename ->
+                        if (filename.contains(".jar") && dependencyName != null) {
+                            dependencyName = "${dependencyName}.jar"
+                            println "Renaming dependency file to : ${dependencyName}"
+                            return dependencyName
+                        }
+                        return filename
+                    }
+                }
+            }
+        }
+    }
+}

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip


### PR DESCRIPTION
Faced some issues during converting to new Gradle - since there is no "prepareReleaseDependencies" task, I had copy dependencies right from Gradle cache. 
Also made small refactor AnvilGenPlugin, since there is no need checking internal jars anymore and needed to provide separate version for "android.arch" dependencies.
